### PR TITLE
Only call close() when modal is toggled

### DIFF
--- a/src/modal.js
+++ b/src/modal.js
@@ -62,7 +62,7 @@ export default class extends Controller {
   }
 
   closeWithKeyboard(e) {
-    if (e.keyCode == 27) {
+    if (e.keyCode == 27 && !this.containerTarget.classList.contains(this.toggleClass)) {
       this.close(e)
     }
   }


### PR DESCRIPTION
Similar fix as  
https://github.com/excid3/tailwindcss-stimulus-components/pull/5 to only call close() on ESC key if modal is toggled.