### PR TITLE
Update modal to save and restore scroll position

### DIFF
--- a/src/modal.js
+++ b/src/modal.js
@@ -9,7 +9,7 @@
   //</a>
 
   //<!-- Modal Container -->
-  //<div data-target="modal.container" data-action="click->modal#closeBackground" class="hidden animated fadeIn fixed top-0 left-0 right-0 bottom-0 flex items-center justify-center" style="z-index: 9999;">
+  //<div data-target="modal.container" data-action="click->modal#closeBackground keyup@window->modal#closeWithKeyboard" class="hidden animated fadeIn fixed top-0 left-0 right-0 bottom-0 flex items-center justify-center" style="z-index: 9999;">
     //<!-- Modal Inner Container -->
     //<div class="w-full max-w-lg relative">
       //<!-- Modal Card -->
@@ -27,72 +27,103 @@
   //</div>
 //</div>
 
-import { Controller } from 'stimulus'
+import { Controller } from 'stimulus';
 
 export default class extends Controller {
-  static targets = ['container']
+  static targets = ['container'];
 
   connect() {
     // The class we should toggle on the container
-    this.toggleClass    = this.data.get('class') || 'hidden'
+    this.toggleClass = this.data.get('class') || 'hidden';
 
     // The HTML for the background element
-    this.backgroundHtml = this.data.get('backgroundHtml') || this._backgroundHTML()
+    this.backgroundHtml = this.data.get('backgroundHtml') || this._backgroundHTML();
 
     // The ID of the background to hide/remove
-    this.backgroundId   = this.data.get('backgroundId') || 'modal-background'
+    this.backgroundId = this.data.get('backgroundId') || 'modal-background';
 
     // Let the user close the modal by clicking on the background
-    this.allowBackgroundClose = (this.data.get('allowBackgroundClose') || 'true') === 'true'
+    this.allowBackgroundClose = (this.data.get('allowBackgroundClose') || 'true') === 'true';
   }
 
   open(e) {
-    e.preventDefault()
+    e.preventDefault();
 
-    // Add right padding to the body so the page doesn't shift
-    // when we disable scrolling
-    let scrollbarWidth = window.innerWidth - document.documentElement.clientWidth
-    document.body.style.paddingRight = `${scrollbarWidth}px`
-
-    // Set overflow hidden to prevent scrolling of background
-    // This must happen after the scrollbar calculation
-    document.body.style.overflow = 'hidden'
+    // Lock the scroll and save current scroll position
+    this.lockScroll();
 
     // Unhide the modal
-    this.containerTarget.classList.remove(this.toggleClass)
+    this.containerTarget.classList.remove(this.toggleClass);
 
     // Insert the background
     document.body.insertAdjacentHTML('beforeend', this.backgroundHtml);
-    this.background = document.querySelector('#' + this.backgroundId)
+    this.background = document.querySelector(`#${this.backgroundId}`);
   }
 
   close(e) {
-    e.preventDefault()
+    e.preventDefault();
 
-    // Remove tweaks for scrollbar
-    document.body.style.paddingRight = null
-    document.body.style.overflow = null
+    // Unlock the scroll and restore previous scroll position
+    this.unlockScroll();
 
     // Hide the modal
-    this.containerTarget.classList.add(this.toggleClass)
+    this.containerTarget.classList.add(this.toggleClass);
 
     // Remove the background
-    this.background.remove()
+    this.background.remove();
   }
 
   closeBackground(e) {
     if (this.allowBackgroundClose && e.target === this.containerTarget) {
-      this.close(e)
+      this.close(e);
     }
   }
 
   closeWithKeyboard(e) {
-    if (e.keyCode == 27 && !this.containerTarget.classList.contains(this.toggleClass)) {
-      this.close(e)
+    if (e.keyCode === 27 && !this.containerTarget.classList.contains(this.toggleClass)) {
+      this.close(e);
     }
   }
 
   _backgroundHTML() {
-    return '<div id="modal-background" class="fixed top-0 left-0 w-full h-full" style="background-color: rgba(0, 0, 0, 0.8); z-index: 9998;"></div>'
+    return '<div id="modal-background" class="fixed top-0 left-0 w-full h-full" style="background-color: rgba(0, 0, 0, 0.8); z-index: 9998;"></div>';
+  }
+
+  lockScroll() {
+    // Add right padding to the body so the page doesn't shift
+    // when we disable scrolling
+    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+    document.body.style.paddingRight = `${scrollbarWidth}px`;
+
+    // Save the scroll position
+    this.saveScrollPosition();
+
+    // Add classes to body to fix its position
+    document.body.classList.add('fixed', 'inset-x-0', 'overflow-hidden');
+
+    // Add negative top position in order for body to stay in place
+    document.body.style.top = `-${this.scrollPosition}px`;
+  }
+
+  unlockScroll() {
+    // Remove tweaks for scrollbar
+    document.body.style.paddingRight = null;
+
+    // Remove classes from body to unfix position
+    document.body.classList.remove('fixed', 'inset-x-0', 'overflow-hidden');
+
+    // Restore the scroll position of the body before it got locked
+    this.restoreScrollPosition();
+
+    // Remove the negative top inline style from body
+    document.body.style.top = null;
+  }
+
+  saveScrollPosition() {
+    this.scrollPosition = window.pageYOffset || document.body.scrollTop;
+  }
+
+  restoreScrollPosition() {
+    document.documentElement.scrollTop = this.scrollPosition;
   }
 }


### PR DESCRIPTION
With this added functionality, the modal will now save and restore the scroll position when the body gets locked. This way the body doesn't jump to the top every time you open a modal.

Also there was the `keyup` event missing in the example HTML at the top. Without it, you can't close the modal with the `esc` key.