### PR TITLE
9 7 19/bugfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,11 @@ application.register('modal', Modal)
   </a>
 
   <!-- Modal Container -->
-  <div data-target="modal.container" data-action="click->modal#closeBackground keyup@window->modal#closeWithKeyboard" class="hidden animated fadeIn fixed top-0 left-0 right-0 bottom-0 flex items-center justify-center" style="z-index: 9999;">
+  <div data-target="modal.container" data-action="click->modal#closeBackground keyup@window->modal#closeWithKeyboard" class="hidden animated fadeIn fixed inset-0 overflow-y-auto flex items-center justify-center" style="z-index: 9999;">
     <!-- Modal Inner Container -->
-    <div class="w-full max-w-lg relative">
+    <div class="max-h-screen w-full max-w-lg relative">
       <!-- Modal Card -->
-      <div class="bg-white rounded shadow">
+      <div class="m-1 bg-white rounded shadow">
         <div class="p-8">
           <h2 class="text-xl mb-4">Large Modal Content</h2>
           <p class="mb-4">This is an example modal dialog box.</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -61,11 +61,11 @@
           </a>
 
           <!-- Modal Container -->
-          <div data-target="modal.container" data-action="click->modal#closeBackground keyup@window->modal#closeWithKeyboard" class="hidden animated fadeIn fixed top-0 left-0 right-0 bottom-0 flex items-center justify-center" style="z-index: 9999;">
+          <div data-target="modal.container" data-action="click->modal#closeBackground keyup@window->modal#closeWithKeyboard" class="hidden animated fadeIn fixed inset-0 overflow-y-auto flex items-center justify-center" style="z-index: 9999;">
             <!-- Modal Inner Container -->
-            <div class="w-full max-w-lg relative">
+            <div class="max-h-screen w-full max-w-lg relative">
               <!-- Modal Card -->
-              <div class="bg-white rounded shadow">
+              <div class="m-1 bg-white rounded shadow">
                 <div class="p-8">
                   <h2 class="text-xl mb-4">Large Modal Content</h2>
                   <p class="mb-4">This is an example modal dialog box.</p>

--- a/src/modal.js
+++ b/src/modal.js
@@ -48,6 +48,7 @@ export default class extends Controller {
 
   open(e) {
     e.preventDefault();
+    e.target.blur();
 
     // Lock the scroll and save current scroll position
     this.lockScroll();

--- a/src/modal.js
+++ b/src/modal.js
@@ -9,11 +9,11 @@
   //</a>
 
   //<!-- Modal Container -->
-  //<div data-target="modal.container" data-action="click->modal#closeBackground keyup@window->modal#closeWithKeyboard" class="hidden animated fadeIn fixed top-0 left-0 right-0 bottom-0 flex items-center justify-center" style="z-index: 9999;">
+  //<div data-target="modal.container" data-action="click->modal#closeBackground keyup@window->modal#closeWithKeyboard" class="hidden animated fadeIn fixed inset-0 overflow-y-auto flex items-center justify-center" style="z-index: 9999;">
     //<!-- Modal Inner Container -->
-    //<div class="w-full max-w-lg relative">
+    //<div class="max-h-screen w-full max-w-lg relative">
       //<!-- Modal Card -->
-      //<div class="bg-white rounded shadow">
+      //<div class="m-1 bg-white rounded shadow">
         //<div class="p-8">
           //<h2 class="text-xl mb-4">Large Modal Content</h2>
           //<p class="mb-4">This is an example modal dialog box.</p>


### PR DESCRIPTION
Added `e.target.blur();` to address #17 

Also modified a few tailwind classes for the modal example so that the modal can be scrolled when the content overflows the screen.