### PR TITLE
Fix anchor bug + add event when switching tabs

### DIFF
--- a/src/tabs.js
+++ b/src/tabs.js
@@ -6,13 +6,15 @@ export default class extends Controller {
   connect() {
     this.activeTabClasses = (this.data.get('activeTab') || 'active').split(' ')
     this.inactiveTabClasses = (this.data.get('inactiveTab') || 'inactive').split(' ')
-    this.index = this.tabTargets.findIndex(tab => tab.id == this.anchor)
+    if (this.anchor) this.index = this.tabTargets.findIndex((tab) => tab.id === this.anchor)
     this.showTab()
   }
 
   change(event) {
     event.preventDefault()
     this.index = this.tabTargets.indexOf(event.currentTarget)
+
+    window.dispatchEvent(new CustomEvent('tsc:tab-change'))
   }
 
   showTab() {
@@ -30,7 +32,6 @@ export default class extends Controller {
           event.preventDefault()
           location.hash = tab.id
         }
-
       } else {
         panel.classList.add('hidden')
         tab.classList.remove(...this.activeTabClasses)


### PR DESCRIPTION
This fixes a bug where the anchor logic would always set `this.index` no matter if an anchor was in the url or not (it would always default to the index being set to 0). This fixes that, so we only set the index if an anchor is given - if not, we rely on the value of `data-tabs-index` if set.

Also, we now dispatch a new CustomEvent named `tsp:tab-change` (tsp for tailwindcss-stimulus-components). This makes it so you can listen to said event in a `data-action` inside one of the tab panels, something like: `data-action="change-tab@window->scroll#updateScrollPosition"`