### PR TITLE
Add slideover component

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,50 @@ data-dropdown-leaving-class="ease-in duration-300"
 data-dropdown-leave-timeout="300"
 ```
 
+### Slideovers
+
+```js
+import { Slideover } from "tailwindcss-stimulus-components"
+application.register('slideover', Slideover)
+```
+
+```html
+<div class="container mx-auto p-8"
+     data-controller="slideover"
+     data-slideover-active-target="#slideover-target">
+  <!-- begin sidebar/slideover -->
+  <div id="sidebar">
+    <div data-target="slideover.overlay" class="fixed inset-0 flex z-40 transition-opacity ease-linear duration-300 opacity-0 hidden">
+      <div class="fixed inset-0">
+        <div class="absolute inset-0 bg-gray-600 opacity-75"></div>
+      </div>
+      <div id="slideover-target" data-target="slideover.menu" class="relative flex-1 flex flex-col max-w-xs w-full pt-5 pb-4 bg-gray-800 transition ease-in-out duration-300 transform -translate-x-full hidden">
+        <div class="absolute top-0 right-0 -mr-14 p-1">
+          <button data-action="slideover#_hide" class="flex items-center justify-center h-12 w-12 rounded-full focus:outline-none focus:bg-gray-600" aria-label="Close sidebar">
+            <svg class="h-6 w-6 text-white" stroke="currentColor" fill="none" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        <!-- menu content -->
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+Slideovers are glorified dropdowns that include an additional overlay. Thus, the setup is equivalent to that of dropdowns, albeit you must specify an `overlay` target. Animations are annotated similarly to dropdowns, just separate the `classList`s of menu and overlay with a comma `,`:
+
+```html
+data-slideover-invisible-class="-translate-x-full,opacity-0"
+data-slideover-visible-class="translate-x-0,opacity-100"
+data-slideover-entering-class=""
+data-slideover-enter-timeout="300,300"
+data-slideover-leaving-class=""
+data-slideover-leave-timeout="300,0"
+```
+
+
 ### Modals
 
 ![Modal](https://d3vv6lp55qjaqc.cloudfront.net/items/3V2t3f0K0B1J3B2t0k0u/Screen%20Shot%202018-12-07%20at%201.01.22%20PM.png?X-CloudApp-Visitor-Id=bcd17e7039e393c836f30de901088b96&v=fa2ab240)

--- a/docs/index.html
+++ b/docs/index.html
@@ -203,7 +203,7 @@
     </div>
 
     <!-- Alert -->
-    <div class="fixed inset-x-0 top-0 flex items-end justify-right px-4 py-6 sm:p-6 justify-end z-50 ">
+    <div class="fixed inset-x-0 top-0 flex items-end justify-right px-4 py-6 sm:p-6 justify-end z-30 ">
       <div data-controller="alert" class="max-w-sm w-full shadow-lg rounded px-4 py-3 rounded relative bg-green-400 border-l-4 border-green-700 text-white">
         <div class="p-2">
           <div class="flex items-start">

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,7 +10,45 @@
     <script src="../dist/tailwindcss-stimulus-components.umd.js"></script>
     -->
   <body>
-    <div class="container mx-auto p-8">
+    <div class="container mx-auto p-8"
+         data-controller="slideover"
+         data-slideover-invisible-class="-translate-x-full,opacity-0"
+         data-slideover-visible-class="translate-x-0,opacity-100"
+         data-slideover-entering-class=""
+         data-slideover-enter-timeout="300,300"
+         data-slideover-leaving-class=""
+         data-slideover-leave-timeout="300,0"
+         data-slideover-active-target="#slideover-target">
+      <!-- begin sidebar/slideover -->
+      <div id="sidebar-mobile">
+        <div data-target="slideover.overlay" class="fixed inset-0 flex z-40 transition-opacity ease-linear duration-300 opacity-0 hidden">
+          <div class="fixed inset-0">
+            <div class="absolute inset-0 bg-gray-600 opacity-75"></div>
+          </div>
+          <div id="slideover-target" data-target="slideover.menu" class="relative flex-1 flex flex-col max-w-xs w-full pt-5 pb-4 bg-gray-800 transition ease-in-out duration-300 transform -translate-x-full hidden">
+            <div class="absolute top-0 right-0 -mr-14 p-1">
+              <button data-action="slideover#_hide" class="flex items-center justify-center h-12 w-12 rounded-full focus:outline-none focus:bg-gray-600" aria-label="Close sidebar">
+                <svg class="h-6 w-6 text-white" stroke="currentColor" fill="none" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+            <div class="flex-shrink-0 flex items-center px-4">
+              <h1 class="text-white text-2xl font-bold">Sidebar</h1>
+            </div>
+            <div class="mt-5 flex-1 h-0 overflow-y-auto">
+              <nav class="px-2 space-y-1">
+              </nav>
+            </div>
+          </div>
+          <div class="flex-shrink-0 w-14">
+            <!-- Dummy element to force sidebar to shrink to fit close icon -->
+          </div>
+        </div>
+      </div>
+
+      <!-- end sidebar/slideover -->
+      
       <h1 class="text-3xl font-semibold mb-2">Tailwind Stimulus Components Examples</h1>
       <img src="https://img.shields.io/npm/v/tailwindcss-stimulus-components.svg" class="inline-block mr-2" />
       <a href="https://github.com/excid3/tailwindcss-stimulus-components" class="text-blue-500">View on Github</a>
@@ -52,6 +90,13 @@
             </div>
           </div>
         </nav>
+      </div>
+
+      <div class="my-12">
+        <h2 class="text-2xl text-gray-800 font-semibold mb-4">Slideovers</h2>
+        <button data-action="click->slideover#toggle click@window->slideover#hide" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded">
+          <span>Open Slideover</span>
+        </button>
       </div>
 
       <div class="my-12">
@@ -186,6 +231,7 @@
       application.register('tabs', TailwindcssStimulusComponents.Tabs);
       application.register('popover', TailwindcssStimulusComponents.Popover);
       application.register('alert', TailwindcssStimulusComponents.Alert);
+      application.register('slideover', TailwindcssStimulusComponents.Slideover);
     </script>
   </body>
 </html>

--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -35,9 +35,7 @@ export default class extends Controller {
     this.invisibleClass = this.data.get('invisibleClass') || null
     this.activeClass = this.data.get('activeClass') || null
     this.enteringClass = this.data.get('enteringClass') || null
-    this.enterTimeout = parseInt(this.data.get('enterTimeout')) || 0
     this.leavingClass = this.data.get('leavingClass') || null
-    this.leaveTimeout = parseInt(this.data.get('leaveTimeout')) || 0
   }
 
   toggle() {
@@ -48,44 +46,52 @@ export default class extends Controller {
     }
   }
 
-  _show() {
+  _show(cb) {
     this.menuTarget.classList.remove(this.toggleClass)
-    this._enteringClassList.forEach(
+    this._enteringClassList[0].forEach(
       (klass => {
         this.menuTarget.classList.add(klass)
       }).bind(this),
     )
 
-    requestAnimationFrame(
+    setTimeout(
       (() => {
-        this._visibleClassList.forEach(klass => {
-          this.menuTarget.classList.add(klass)
-        })
-        this._activeClassList.forEach(klass => {
+        this._activeClassList[0].forEach(klass => {
           this.activeTarget.classList.add(klass)
         })
-        this._invisibleClassList.forEach(klass => this.menuTarget.classList.remove(klass))
+        this._invisibleClassList[0].forEach(klass => this.menuTarget.classList.remove(klass))
+        this._visibleClassList[0].forEach(klass => {
+          this.menuTarget.classList.add(klass)
+        })
         setTimeout(
           (() => {
-            this._enteringClassList.forEach(klass => this.menuTarget.classList.remove(klass))
+            this._enteringClassList[0].forEach(klass => this.menuTarget.classList.remove(klass))
           }).bind(this),
-          this.enterTimeout,
+          this.enterTimeout[0],
         )
+
+        if (cb) cb()
       }).bind(this),
     )
   }
 
-  _hide() {
-    this._invisibleClassList.forEach(klass => this.menuTarget.classList.add(klass))
-    this._visibleClassList.forEach(klass => this.menuTarget.classList.remove(klass))
-    this._activeClassList.forEach(klass => this.activeTarget.classList.remove(klass))
-    this._leavingClassList.forEach(klass => this.menuTarget.classList.add(klass))
+  _hide(cb) {
     setTimeout(
       (() => {
-        this.menuTarget.classList.add(this.toggleClass)
-        this._leavingClassList.forEach(klass => this.menuTarget.classList.remove(klass))
+        this._invisibleClassList[0].forEach(klass => this.menuTarget.classList.add(klass))
+        this._visibleClassList[0].forEach(klass => this.menuTarget.classList.remove(klass))
+        this._activeClassList[0].forEach(klass => this.activeTarget.classList.remove(klass))
+        this._leavingClassList[0].forEach(klass => this.menuTarget.classList.add(klass))
+        setTimeout(
+          (() => {
+            this._leavingClassList[0].forEach(klass => this.menuTarget.classList.remove(klass))
+            if (cb) cb()
+
+            this.menuTarget.classList.add(this.toggleClass)
+          }).bind(this),
+          this.leaveTimeout[0],
+        )
       }).bind(this),
-      this.leaveTimeout,
     )
   }
 
@@ -106,22 +112,50 @@ export default class extends Controller {
   }
 
   get _activeClassList() {
-    return !this.activeClass ? [] : this.activeClass.split(' ')
+    return !this.activeClass
+      ? [[], []]
+      : this.activeClass.split(',').map(classList => classList.split(' '))
   }
 
   get _visibleClassList() {
-    return !this.visibleClass ? [] : this.visibleClass.split(' ')
+    return !this.visibleClass
+      ? [[], []]
+      : this.visibleClass.split(',').map(classList => classList.split(' '))
   }
 
   get _invisibleClassList() {
-    return !this.invisibleClass ? [] : this.invisibleClass.split(' ')
+    return !this.invisibleClass
+      ? [[], []]
+      : this.invisibleClass.split(',').map(classList => classList.split(' '))
   }
 
   get _enteringClassList() {
-    return !this.enteringClass ? [] : this.enteringClass.split(' ')
+    return !this.enteringClass
+      ? [[], []]
+      : this.enteringClass.split(',').map(classList => classList.split(' '))
   }
 
   get _leavingClassList() {
-    return !this.leavingClass ? [] : this.leavingClass.split(' ')
+    return !this.leavingClass
+      ? [[], []]
+      : this.leavingClass.split(',').map(classList => classList.split(' '))
+  }
+
+  get enterTimeout() {
+    return (
+      this.data
+        .get('enterTimeout')
+        .split(',')
+        .map(timeout => parseInt(timeout)) || [0, 0]
+    )
+  }
+
+  get leaveTimeout() {
+    return (
+      this.data
+        .get('leaveTimeout')
+        .split(',')
+        .map(timeout => parseInt(timeout)) || [0, 0]
+    )
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -5,5 +5,6 @@ import Modal from './modal'
 import Tabs from './tabs'
 import Toggle from './toggle'
 import Popover from './popover'
+import Slideover from './slideover'
 
-export { Alert, Autosave, Dropdown, Modal, Tabs, Toggle, Popover }
+export { Alert, Autosave, Dropdown, Modal, Tabs, Toggle, Popover, Slideover }

--- a/src/slideover.js
+++ b/src/slideover.js
@@ -1,12 +1,12 @@
 // <div role="main" class="h-screen flex overflow-hidden bg-gray-100"
 //      data-controller="slideover"
-//      data-sidebar-inactive-class="-translate-x-full,opacity-0"
-//      data-sidebar-active-class="translate-x-0,opacity-100"
-//      data-sidebar-entering-class=""
-//      data-sidebar-enter-timeout="300,300"
-//      data-sidebar-leaving-class=""
-//      data-sidebar-leave-timeout="300,300"
-//      data-sidebar-active-target="#sidebar-target">
+//      data-slideover-invisible-class="-translate-x-full,opacity-0"
+//      data-slideover-visible-class="translate-x-0,opacity-100"
+//      data-slideover-entering-class=""
+//      data-slideover-enter-timeout="300,300"
+//      data-slideover-leaving-class=""
+//      data-slideover-leave-timeout="300,300"
+//      data-slideover-active-target="#slideover-target">
 
 import Dropdown from './dropdown.js'
 

--- a/src/slideover.js
+++ b/src/slideover.js
@@ -1,3 +1,8 @@
+// Visit The Stimulus Handbook for more details
+// https://stimulusjs.org/handbook/introduction
+
+// This example controller works with specially annotated HTML like:
+
 // <div role="main" class="h-screen flex overflow-hidden bg-gray-100"
 //      data-controller="slideover"
 //      data-slideover-invisible-class="-translate-x-full,opacity-0"
@@ -7,6 +12,23 @@
 //      data-slideover-leaving-class=""
 //      data-slideover-leave-timeout="300,300"
 //      data-slideover-active-target="#slideover-target">
+//      <div id="sidebar">
+//        <div data-target="slideover.overlay" class="fixed inset-0 flex z-40 transition-opacity ease-linear duration-300 opacity-0 hidden">
+//          <div class="fixed inset-0">
+//            <div class="absolute inset-0 bg-gray-600 opacity-75"></div>
+//          </div>
+//          <div id="slideover-target" data-target="slideover.menu" class="relative flex-1 flex flex-col max-w-xs w-full pt-5 pb-4 bg-gray-800 transition ease-in-out duration-300 transform -translate-x-full hidden">
+//            <div class="absolute top-0 right-0 -mr-14 p-1">
+//              <button data-action="slideover#_hide" class="flex items-center justify-center h-12 w-12 rounded-full focus:outline-none focus:bg-gray-600" aria-label="Close sidebar">
+//                <svg class="h-6 w-6 text-white" stroke="currentColor" fill="none" viewBox="0 0 24 24">
+//                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+//                </svg>
+//              </button>
+//            </div>
+//          </div>
+//        </div>
+//      </div>
+// </div>
 
 import Dropdown from './dropdown.js'
 

--- a/src/slideover.js
+++ b/src/slideover.js
@@ -1,0 +1,52 @@
+// <div role="main" class="h-screen flex overflow-hidden bg-gray-100"
+//      data-controller="slideover"
+//      data-sidebar-inactive-class="-translate-x-full,opacity-0"
+//      data-sidebar-active-class="translate-x-0,opacity-100"
+//      data-sidebar-entering-class=""
+//      data-sidebar-enter-timeout="300,300"
+//      data-sidebar-leaving-class=""
+//      data-sidebar-leave-timeout="300,300"
+//      data-sidebar-active-target="#sidebar-target">
+
+import Dropdown from './dropdown.js'
+
+export default class extends Dropdown {
+  static targets = ['menu', 'overlay']
+
+  _show() {
+    this.overlayTarget.classList.remove(this.toggleClass)
+
+    super._show(
+      (() => {
+        this._activeClassList[1].forEach(klass => this.overlayTarget.classList.add(klass))
+        this._invisibleClassList[1].forEach(klass => this.overlayTarget.classList.remove(klass))
+        this._visibleClassList[1].forEach(klass => this.overlayTarget.classList.add(klass))
+        setTimeout(
+          (() => {
+            this._enteringClassList[1].forEach(klass => this.overlayTarget.classList.remove(klass))
+          }).bind(this),
+          this.enterTimeout[1],
+        )
+      }).bind(this),
+    )
+  }
+
+  _hide() {
+    this._leavingClassList[1].forEach(klass => this.overlayTarget.classList.add(klass))
+
+    super._hide(
+      (() => {
+        setTimeout(
+          (() => {
+            this._visibleClassList[1].forEach(klass => this.overlayTarget.classList.remove(klass))
+            this._invisibleClassList[1].forEach(klass => this.overlayTarget.classList.add(klass))
+            this._activeClassList[1].forEach(klass => this.overlayTarget.classList.remove(klass))
+            this._leavingClassList[1].forEach(klass => this.overlayTarget.classList.remove(klass))
+            this.overlayTarget.classList.add(this.toggleClass)
+          }).bind(this),
+          this.leaveTimeout[1],
+        )
+      }).bind(this),
+    )
+  }
+}


### PR DESCRIPTION
This PR adds a slideover component, which is basically just a dropdown with a backdrop/overlay.

So I extended the `Dropdown` and added callbacks so that you can now do this:

```html
<div role="main" class="h-screen flex overflow-hidden bg-gray-100"
     data-controller="slideover"
     data-sidebar-inactive-class="-translate-x-full,opacity-0"
     data-sidebar-active-class="translate-x-0,opacity-100"
     data-sidebar-entering-class=""
     data-sidebar-enter-timeout="300,300"
     data-sidebar-leaving-class=""
     data-sidebar-leave-timeout="300,300"
     data-sidebar-active-target="#sidebar-target">
```

Note that the Dropdown remains fully functional, as this video demonstrates:

![slideover-demo](https://user-images.githubusercontent.com/4352208/99376446-3eab1580-28c5-11eb-9fdd-5b53f45df951.gif)

I'll add a demo and documentation, just let me know if this is at all interesting to you.
