### PR TITLE
Move class toggling inside setTimeout

### DIFF
--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -52,15 +52,15 @@ export default class extends Controller {
   }
 
   _show(cb) {
-    this.menuTarget.classList.remove(this.toggleClass)
-    this._enteringClassList[0].forEach(
-      (klass => {
-        this.menuTarget.classList.add(klass)
-      }).bind(this),
-    )
-
     setTimeout(
       (() => {
+        this.menuTarget.classList.remove(this.toggleClass)
+        this._enteringClassList[0].forEach(
+          (klass => {
+            this.menuTarget.classList.add(klass)
+          }).bind(this),
+        )
+
         this._activeClassList[0].forEach(klass => {
           this.activeTarget.classList.add(klass)
         })


### PR DESCRIPTION
This apparently is needed for the `remove` of class `hidden` to work when you want to display the dropdown menu on page load by setting `data-dropdown-open-value="true"`