### PR TITLE
Fix pointer events when alerts visible.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ end
 And then add something like this either directly in the layout file, or in a partial
 that's rendered directly by the layout:
 ```html
-<div class="fixed inset-x-0 top-0 flex items-end justify-right px-4 py-6 sm:p-6 justify-end z-50 ">
-  <div data-controller="alert" class="max-w-sm w-full shadow-lg rounded px-4 py-3 rounded relative bg-green-400 border-l-4 border-green-700 text-white">
+<div class="fixed inset-x-0 top-0 flex items-end justify-right px-4 py-6 sm:p-6 justify-end z-30 pointer-events-none">
+  <div data-controller="alert" class="max-w-sm w-full shadow-lg rounded px-4 py-3 rounded relative bg-green-400 border-l-4 border-green-700 text-white pointer-events-auto">
     <div class="p-2">
       <div class="flex items-start">
         <div class="ml-3 w-0 flex-1 pt-0.5">

--- a/__tests__/fixtures/index.html
+++ b/__tests__/fixtures/index.html
@@ -191,8 +191,8 @@
 </div>
 
 <!-- Alert -->
-<div class="fixed inset-x-0 top-0 flex items-end justify-right px-4 py-6 sm:p-6 justify-end z-30 ">
-  <div data-controller="alert" class="max-w-sm w-full shadow-lg rounded px-4 py-3 rounded relative bg-green-400 border-l-4 border-green-700 text-white">
+<div class="fixed inset-x-0 top-0 flex items-end justify-right px-4 py-6 sm:p-6 justify-end z-30 pointer-events-none">
+  <div data-controller="alert" class="max-w-sm w-full shadow-lg rounded px-4 py-3 rounded relative bg-green-400 border-l-4 border-green-700 text-white pointer-events-auto">
     <div class="p-2">
       <div class="flex items-start">
         <div class="ml-3 w-0 flex-1 pt-0.5">

--- a/docs/index.html
+++ b/docs/index.html
@@ -205,8 +205,8 @@
     </div>
 
     <!-- Alert -->
-    <div class="fixed inset-x-0 top-0 flex items-end justify-right px-4 py-6 sm:p-6 justify-end z-30 ">
-      <div data-controller="alert" class="max-w-sm w-full shadow-lg rounded px-4 py-3 rounded relative bg-green-400 border-l-4 border-green-700 text-white">
+    <div class="fixed inset-x-0 top-0 flex items-end justify-right px-4 py-6 sm:p-6 justify-end z-30 pointer-events-none">
+      <div data-controller="alert" class="max-w-sm w-full shadow-lg rounded px-4 py-3 rounded relative bg-green-400 border-l-4 border-green-700 text-white pointer-events-auto">
         <div class="p-2">
           <div class="flex items-start">
             <div class="ml-3 w-0 flex-1 pt-0.5">

--- a/src/alert.js
+++ b/src/alert.js
@@ -5,8 +5,8 @@
 //
 // This example controller works with specially annotated HTML like:
 //
-//  <div class="fixed inset-x-0 top-0 flex items-end justify-right px-4 py-6 sm:p-6 justify-end z-50 ">
-//     <div data-controller="alert" class="max-w-sm w-full shadow-lg rounded px-4 py-3 rounded relative bg-green-400 border-l-4 border-green-700 text-white">
+//  <div class="fixed inset-x-0 top-0 flex items-end justify-right px-4 py-6 sm:p-6 justify-end z-30 pointer-events-none">
+//     <div data-controller="alert" class="max-w-sm w-full shadow-lg rounded px-4 py-3 rounded relative bg-green-400 border-l-4 border-green-700 text-white pointer-events-auto">
 //       <div class="p-2">
 //         <div class="flex items-start">
 //           <div class="ml-3 w-0 flex-1 pt-0.5">


### PR DESCRIPTION
The alerts had a minor glitch: their fixed container partially obscures
the underlying page for pointer events, including click and hover.  Evident
on the demo page, where the "View on Github" link is unusable.

The fix here is nullifying pointer events for the container and enabling
them only for the visible parts of the alert.