### PR TITLE
Fix undefined toggleClass in the toggle_controller.js

### DIFF
--- a/src/toggle.js
+++ b/src/toggle.js
@@ -15,6 +15,8 @@ export default class extends Controller {
   }
 
   openValueChanged() {
+    if (!this.toggleClass) { return }
+
     this.toggleableTargets.forEach(target => {
       target.classList.toggle(this.toggleClass)
     })


### PR DESCRIPTION
openValueChanged function fires before connect(), this will run an unnecessary loop.
Also, since this.toggleClass is undefined, this function will add an undefined class to an element.
You can see it on the jumpstartrails.com website as well.

![image](https://user-images.githubusercontent.com/32100/109918734-4a3a1500-7cd9-11eb-8924-52364c5ac1fd.png)
