### PR TITLE
Work with rails redirect

### DIFF
--- a/src/tabs.js
+++ b/src/tabs.js
@@ -8,6 +8,17 @@ export default class extends Controller {
     this.inactiveTabClasses = (this.data.get('inactiveTab') || 'inactive').split(' ')
     if (this.anchor) this.index = this.tabTargets.findIndex((tab) => tab.id === this.anchor)
     this.showTab()
+
+    //if there is a redirect, we won't get the correct url until the turbo:load is fired
+    var self = this;
+    this.turboLoadListener = function(event) {
+      self.setTabFromLocation()
+    }
+    document.addEventListener('turbo:load', this.turboLoadListener);
+  }
+
+  disconnect() {
+    document.removeEventListener('turbo:load', this.turboLoadListener);
   }
 
   change(event) {

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -61,6 +61,8 @@ export default class extends Controller {
   }
 
   get anchor() {
-    return (document.URL.split('#').length > 1) ? document.URL.split('#')[1] : null;
+    const bookmark = (document.URL.split('#').length > 1) ? document.URL.split('#')[1] : null;
+    const param = (new URLSearchParams(window.location.search)).get("tab")
+    return bookmark || param
   }
 }


### PR DESCRIPTION
This change was motivated by a notification in JumpstartRails
the notification is generated when someone makes a comment
I want the notification to redirect to a page - but to show the comments tab

e.g. I started with
```
 class NewComment < ApplicationNotification

...

  def url
    # You can use any URL helpers here such as:
    # post_path(params[:post])
    the_comment.commentable.public_url+"#comments"
  end
```

when the user clicks on the notification, the link is a get to

`/notifications/:id`
which redirects to
`/resource#comments`

this hits two problems:

1) connect is called while the url is still `/notifications/:id`
this is fixed by adding a listener for turbo:load

2) even then, the hash part is lost
this is fixed by allowing the format `/resource?tab=comments`

