### PR TITLE
adds hide and show methods to manually show a toggleable without having...

### DIFF
--- a/src/toggle.js
+++ b/src/toggle.js
@@ -14,6 +14,18 @@ export default class extends Controller {
     this.openValue = !this.openValue
   }
 
+  hide(event) {
+    event.preventDefault();
+
+    this.openValue = false;
+  }
+
+  show(event) {
+    event.preventDefault();
+
+    this.openValue = true;
+  }
+
   openValueChanged() {
     if (!this.toggleClass) { return }
 


### PR DESCRIPTION
this adds two methods to the `toggle` component. namely two methods hide and show.

**### Background**

So, in some cases we want a specific target to be only responsible for one action, such as only hiding or showing. In case a user clicks multiple times on a target that we only want to perform one action, thus this controller doesn't quite work in that cases.

Let me show you form  my UI

![image](https://user-images.githubusercontent.com/38360603/114676365-e5c79800-9d11-11eb-91b5-0bab9310f7b7.png)
![image](https://user-images.githubusercontent.com/38360603/114676480-009a0c80-9d12-11eb-903f-9802a86389f0.png)


the desired behavior is when the user clicks the first `div` it should always hide the toggleable, which in case are the date pickers on the second div. But currently, if the user clicks on the first div multiple times (because they will) the div will always toggle the toggleable, which creates a weird behavior to the UI. because the first div when clicked, it should always hide the toggleable, and the second should always show the toggleable 