### PR TITLE
Add color picker and preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,35 @@ In this example, clicking the question will toggle the hidden class. The hidden 
 </div>
 ```
 
+### Color Picker and Preview
+
+```html
+<div class="col-span-6 sm:col-span-3">
+  <label for="hex_color_bg" class="block text-sm font-medium text-gray-700">
+    Color
+  </label>
+  <div class="mt-3 flex items-center" data-controller="color-preview">
+    <p data-color-preview-target="preview"
+       class="h-10 w-10 mr-2 rounded-full text-2xl text-white text-center"
+       style="background-color: #ba1e03; color: #fff; padding-top: 1px;">
+      A
+    </p>
+    <span class="ml-2">
+      <div class="flex rounded-md shadow-sm">
+        <span class="inline-flex items-center px-3 rounded-l-md border border-r-0 border-gray-300 bg-gray-50 text-gray-500">
+          #
+        </span>
+        <input data-action="input->color-preview#update" data-color-preview-target="color"
+               id="hex_color_bg" name="hex_color_bg" type="color" value="#ba1e03"
+               class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md flex-1 rounded-none rounded-r-md mt-0 w-24 h-8 px-1 py-1 border" />
+      </div>
+    </span>
+  </div>
+</div>
+```
+
+This will update the `backgroundColor` by default but you can choose to have the color preview update the `color` instead by setting the `data-color-preview-style="color"` attribute of the color preview controller.
+
 ## Styling
 
 All of the styles for the Stimulus components are configurable. Our

--- a/docs/index.html
+++ b/docs/index.html
@@ -202,6 +202,33 @@
           </div>
         </div>
       </div>
+
+      <!-- Color Picker and Preview -->
+      <div class="my-12">
+        <h2 class="text-2xl text-gray-800 font-semibold mb-4">Color Picker and Preview</h2>
+        <div class="col-span-6 sm:col-span-3">
+          <label for="hex_color_bg" class="block text-sm font-medium text-gray-700 ">
+            Color
+          </label>
+          <div class="mt-3 flex items-center" data-controller="color-preview">
+            <p data-color-preview-target="preview"
+               class="h-10 w-10 mr-2 rounded-full text-2xl text-white text-center"
+               style="background-color: #ba1e03; color: #fff; padding-top: 1px;">
+              A
+            </p>
+            <span class="ml-2">
+              <div class="flex rounded-md shadow-sm">
+                <span class="inline-flex items-center px-3 rounded-l-md border border-r-0 border-gray-300 bg-gray-50 text-gray-500">
+                  #
+                </span>
+                <input data-action="input->color-preview#update" data-color-preview-target="color"
+                       id="hex_color_bg" name="hex_color_bg" type="color" value="#ba1e03"
+                       class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md flex-1 rounded-none rounded-r-md mt-0 w-24 h-8 px-1 py-1 border" />
+              </div>
+            </span>
+          </div>
+        </div>
+      </div>
     </div>
 
     <!-- Alert -->
@@ -234,6 +261,7 @@
       application.register('popover', TailwindcssStimulusComponents.Popover);
       application.register('alert', TailwindcssStimulusComponents.Alert);
       application.register('slideover', TailwindcssStimulusComponents.Slideover);
+      application.register('color_preview', TailwindcssStimulusComponents.ColorPreview);
     </script>
   </body>
 </html>

--- a/src/color_preview.js
+++ b/src/color_preview.js
@@ -1,0 +1,75 @@
+// A color picker preview where you can choose to have the color or backgroundColor
+// get updated based on the result of a color picker. It also supports ensuring
+// the foreground text is always readable by performing a YIQ calculation to
+// set the text to black or white based on the contrast of the color and backgroundColor.
+//
+// The example below uses the native HTML5 color picker for picking the color but
+// you can swap it with anything you'd like:
+//
+// <div class="col-span-6 sm:col-span-3">
+//   <label for="hex_color_bg" class="block text-sm font-medium text-gray-700">
+//     Color
+//   </label>
+//   <div class="mt-3 flex items-center" data-controller="color-preview">
+//     <p data-color-preview-target="preview"
+//        class="h-10 w-10 mr-2 rounded-full text-2xl text-white text-center"
+//        style="background-color: #ba1e03; color: #fff; padding-top: 1px;">
+//       A
+//     </p>
+//     <span class="ml-2">
+//       <div class="flex rounded-md shadow-sm">
+//         <span class="inline-flex items-center px-3 rounded-l-md border border-r-0 border-gray-300 bg-gray-50 text-gray-500">
+//           #
+//         </span>
+//         <input data-action="input->color-preview#update" data-color-preview-target="color"
+//                id="hex_color_bg" name="hex_color_bg" type="color" value="#ba1e03"
+//                class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md flex-1 rounded-none rounded-r-md mt-0 w-24 h-8 px-1 py-1 border" />
+//       </div>
+//     </span>
+//   </div>
+// </div>
+
+import { Controller } from 'stimulus';
+
+export default class extends Controller {
+  static targets = ['preview', 'color'];
+
+  connect() {
+    this.styleProperty = this.data.get('style') || 'backgroundColor';
+  }
+
+  update() {
+    this.preview = this.color;
+  }
+
+  set preview(color) {
+    this.previewTarget.style[this.styleProperty] = color;
+
+    // Ensure the foreground text is always readable by setting either the
+    // backgroundColor or color to black or white.
+    const yiqColor = this._getContrastYIQ(color);
+
+    if (this.styleProperty === 'color') {
+        this.previewTarget.style.backgroundColor = yiqColor;
+    } else {
+        this.previewTarget.style.color = yiqColor;
+    }
+  }
+
+  get color() {
+    return this.colorTarget.value;
+  }
+
+  _getContrastYIQ(hexColor) {
+    // Taken from: https://24ways.org/2010/calculating-color-contrast/
+    hexColor = hexColor.replace('#', '');
+
+    const yiqThreshold = 128;
+    const r = parseInt(hexColor.substr(0, 2), 16);
+    const g = parseInt(hexColor.substr(2, 2), 16);
+    const b = parseInt(hexColor.substr(4, 2), 16);
+    const yiq = ((r * 299) + (g * 587) + (b * 114)) / 1000;
+
+    return (yiq >= yiqThreshold) ? '#000' : '#fff';
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -6,5 +6,6 @@ import Tabs from './tabs'
 import Toggle from './toggle'
 import Popover from './popover'
 import Slideover from './slideover'
+import ColorPreview from './color_preview'
 
-export { Alert, Autosave, Dropdown, Modal, Tabs, Toggle, Popover, Slideover }
+export { Alert, Autosave, Dropdown, Modal, Tabs, Toggle, Popover, Slideover, ColorPreview }


### PR DESCRIPTION
Hi,

The implementation is working outside of your documentation page but I can't figure out how to make it work inside of your docs. It always throws a JS error of `Cannot read property 'prototype' of undefined`. Maybe it's due to how the JS is being compiled?

All I did was drop in the JS, I didn't change any of the UMD bits.

Another docs related issue is I've set CSS classes on the color picker based on using this NPM package `"@tailwindcss/forms": "0.3.2"`. This isn't available in your docs so the color picker looks totally busted. Any suggestions on how you want to handle that? It took a lot of tinkering for it to look correct in all major browsers (with that form plugin). If you can make it look good without that plugin please do it up!

Here's a screenshot of what it looks like outside of the docs:

![image](https://user-images.githubusercontent.com/813219/115262633-b72b3200-a102-11eb-9414-ac9019891163.png)

