### PR TITLE
Fix color preview input being vertically offset by a few pixels

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ In this example, clicking the question will toggle the hidden class. The hidden 
         </span>
         <input data-action="input->color-preview#update" data-color-preview-target="color"
                id="hex_color_bg" name="hex_color_bg" type="color" value="#ba1e03"
-               class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md flex-1 rounded-none rounded-r-md mt-0 w-24 h-8 px-1 py-1 border" />
+               class="focus:ring-indigo-500 focus:border-indigo-500 block shadow-sm sm:text-sm border-gray-300 flex-1 rounded-r-md mt-0 w-24 h-8 px-1 py-1 border" />
       </div>
     </span>
   </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -224,7 +224,7 @@
                 </span>
                 <input data-action="input->color-preview#update" data-color-preview-target="color"
                        id="hex_color_bg" name="hex_color_bg" type="color" value="#ba1e03"
-                       class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block shadow-sm sm:text-sm border-gray-300 rounded-md flex-1 rounded-none rounded-r-md mt-0 w-24 h-8 px-1 py-1 border" />
+                       class="focus:ring-indigo-500 focus:border-indigo-500 block shadow-sm sm:text-sm border-gray-300 flex-1 rounded-r-md mt-0 w-24 h-8 px-1 py-1 border" />
               </div>
             </span>
           </div>

--- a/src/color_preview.js
+++ b/src/color_preview.js
@@ -23,7 +23,7 @@
 //         </span>
 //         <input data-action="input->color-preview#update" data-color-preview-target="color"
 //                id="hex_color_bg" name="hex_color_bg" type="color" value="#ba1e03"
-//                class="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md flex-1 rounded-none rounded-r-md mt-0 w-24 h-8 px-1 py-1 border" />
+//                class="focus:ring-indigo-500 focus:border-indigo-500 block shadow-sm sm:text-sm border-gray-300 flex-1 rounded-r-md mt-0 w-24 h-8 px-1 py-1 border" />
 //       </div>
 //     </span>
 //   </div>


### PR DESCRIPTION
In the current docs the `#` that's prepended to the input is a few pixels too tall. This patch removes a bit of top margin from the input to even them out. Now it matches the screenshot in the original color preview PR #73.