### PR TITLE
change to skypack CDN for docs page

### DIFF
--- a/docs/alert.html
+++ b/docs/alert.html
@@ -69,8 +69,11 @@
     </script>
 
     <script type="module">
-      import { Application } from "@hotwired/stimulus"
-      import { Alert } from "tailwindcss-stimulus-components"
+      import { Application } from 'https://cdn.skypack.dev/@hotwired/stimulus';
+      import { Alert } from "https://cdn.skypack.dev/tailwindcss-stimulus-components"
+
+      // Uncomment to use local package with "npx serve"
+     // import { Alert } from "tailwindcss-stimulus-components"
 
       (() => {
         const application = Application.start();

--- a/docs/index.html
+++ b/docs/index.html
@@ -297,8 +297,11 @@
     </script>
 
     <script type="module">
-      import { Application } from "@hotwired/stimulus"
-      import { Alert, ColorPreview, Dropdown, Modal, Popover, Slideover, Tabs, Toggle } from "tailwindcss-stimulus-components"
+      import { Application } from 'https://cdn.skypack.dev/@hotwired/stimulus';
+      import { Alert, ColorPreview, Dropdown, Modal, Popover, Slideover, Tabs, Toggle } from "https://cdn.skypack.dev/tailwindcss-stimulus-components"
+
+      // Uncomment to use local package with "npx serve"
+      //import { Alert, ColorPreview, Dropdown, Modal, Popover, Slideover, Tabs, Toggle } from "tailwindcss-stimulus-components"
 
       (() => {
         const application = Application.start();


### PR DESCRIPTION
Import maps are not supported in [Safari and Firefox](https://caniuse.com/?search=importmap). Hopefully, they will be soon but in the meantime, I think it will be good to use Skypack. 

This relates to [Issue 103](https://github.com/excid3/tailwindcss-stimulus-components/issues/103) 

On the downside, this will make development a bit clunkier. 