### PR TITLE
change slideover#_hide with slideover#toggle on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ application.register('slideover', Slideover)
       </div>
       <div id="slideover-target" data-slideover-target="menu" class="relative flex-1 flex flex-col max-w-xs w-full pt-5 pb-4 bg-gray-800 transition ease-in-out duration-300 transform -translate-x-full hidden">
         <div class="absolute top-0 right-0 -mr-14 p-1">
-          <button data-action="slideover#_hide" class="flex items-center justify-center h-12 w-12 rounded-full focus:outline-none focus:bg-gray-600" aria-label="Close sidebar">
+          <button data-action="slideover#toggle" class="flex items-center justify-center h-12 w-12 rounded-full focus:outline-none focus:bg-gray-600" aria-label="Close sidebar">
             <svg class="h-6 w-6 text-white" stroke="currentColor" fill="none" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
             </svg>


### PR DESCRIPTION
change slideover#_hide with slideover#toggle

the _`hide` have differ action than the toggle 

the `_hide` not close the slideovers completly


the `_hide` only changes `data-slideover-target="overlay" ` class from `hidden` to nothing

the `toggle` change the class status from `slideover-target` from `hidden` to nothing and also change the `data-slideover-open-value` from `true` to `false`
