### PR TITLE
Configurable Alert

### DIFF
--- a/src/alert.js
+++ b/src/alert.js
@@ -6,32 +6,36 @@
 // This example controller works with specially annotated HTML like:
 //
 //  <div class="fixed inset-x-0 top-0 flex items-end justify-right px-4 py-6 sm:p-6 justify-end z-30 pointer-events-none">
-//     <div data-controller="alert" class="max-w-sm w-full shadow-lg rounded px-4 py-3 rounded relative bg-green-400 border-l-4 border-green-700 text-white pointer-events-auto">
-//       <div class="p-2">
-//         <div class="flex items-start">
-//           <div class="ml-3 w-0 flex-1 pt-0.5">
-//             <p class="text-sm leading-5 font-medium">
-//               Stimulus is the JS of the future!
-//             </p>
-//           </div>
-//           <div class="ml-4 flex-shrink-0 flex">
-//             <button data-action="alert#close" class="inline-flex text-white focus:outline-none focus:text-gray-300 transition ease-in-out duration-150">
-//               <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-//                 <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"/>
-//               </svg>
-//             </button>
-//           </div>
-//         </div>
-//       </div>
-//     </div>
-//   </div>
+//    <div data-controller="alert" data-alert-show-class="translate-x-0 opacity-100" data-alert-hide-class="translate-x-full opacity-0" class="max-w-sm w-full shadow-lg px-4 py-3 rounded relative bg-green-400 border-l-4 border-green-700 text-white pointer-events-auto transition translate-x-full transform ease-in-out duration-1000 opacity-0">
+//      <div class="p-2">
+//        <div class="flex items-start">
+//          <div class="ml-3 w-0 flex-1 pt-0.5">
+//            <p class="text-sm leading-5 font-medium">
+//              Stimulus is the JS of the future!
+//            </p>
+//          </div>
+//          <div class="ml-4 flex-shrink-0 flex">
+//            <button data-action="alert#close" class="inline-flex text-white focus:outline-none focus:text-gray-300">
+//              <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+//                <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"/>
+//              </svg>
+//            </button>
+//          </div>
+//        </div>
+//      </div>
+//    </div>
+//  </div>
 
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
   static values = {
-    dismissAfter: Number
+    dismissAfter: Number,
+    showDelay: Number,
+    removeDelay: Number
+
   }
+  static classes = ["show", "hide"]
 
   initialize() {
     this.hide()
@@ -40,7 +44,7 @@ export default class extends Controller {
   connect() {
     setTimeout(() => {
       this.show()
-    }, 200)
+    }, this.showAfter)
 
     // Auto dimiss if defined
     if (this.hasDismissAfterValue) {
@@ -52,23 +56,35 @@ export default class extends Controller {
 
   close() {
     this.hide()
+
     setTimeout(() => {
       this.element.remove()
-    }, 1100)
-
+    }, this.removeAfter)
   }
 
   show() {
-    this.element.setAttribute(
-      'style',
-      "transition: 1s; transform:translate(0, 0);",
-    )
+    this.element.classList.add(...this.showClasses)
+    this.element.classList.remove(...this.hideClasses)
   }
 
   hide() {
-    this.element.setAttribute(
-      'style',
-      "transition: 1s; transform:translate(400px, 0);",
-    )
+    this.element.classList.add(...this.hideClasses)
+    this.element.classList.remove(...this.showClasses)
+  }
+
+  get removeAfter() {
+    if (this.hasRemoveDelayValue) {
+      return this.removeDelayValue
+    } else {
+      return 1100
+    }
+  }
+
+  get showAfter() {
+    if (this.hasShowDelayValue) {
+      return this.showDelayValue
+    } else {
+      return 200
+    }
   }
 }


### PR DESCRIPTION
The alert originally relied on hard coded values to determine the delay before removing or showing the alert. This is replaced with [Stimulus values](https://stimulus.hotwired.dev/reference/values) instead. A default is still supplied.

Likewise the animation of the alert was done through style attributes hard coded in the controller. However Tailwind has classes for this purpose as well. Using [Stimulus' css class API](https://stimulus.hotwired.dev/reference/css-classes) these can be supplied from the DOM too. No default is supplied, as the alert is simply dismissed after its removal delay (if any) has run out.

In the example markup the alert is placed within a div with a horizontal padding. This caused the alert to not be completely out of view, when it was removed from the DOM. I solved this with a little hack, where the opacity is reduced to 0, when hiding the alert: `data-alert-hide-class="translate-x-full opacity-0"` There is probably a better solution, but I could not find any.