### PR TITLE
Add value for backdrop color to modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,8 @@ that opens the modal and set to `false` to allow it. Default: `true`.
 default action from running when clicking the element (e.g. a link from opening)
 that closes the modal and set to `false` to allow it. Default: `true`.
 
+`data-modal-backdrop-color-value` can be used to specify the color and transparency of the modal's backdrop by setting an rgba value. Default: `rgba(0, 0, 0, 0.8)`.
+
 ### Tabs
 
 ![Tabs](https://d3vv6lp55qjaqc.cloudfront.net/items/440B1H1P2Y1r3C3r1h0R/Screen%20Shot%202018-12-07%20at%201.24.31%20PM.png?X-CloudApp-Visitor-Id=bcd17e7039e393c836f30de901088b96&v=84e44dbd)

--- a/src/modal.js
+++ b/src/modal.js
@@ -30,7 +30,10 @@
 import { Controller } from '@hotwired/stimulus';
 
 export default class extends Controller {
-  static targets = ['container'];
+  static targets = ['container']
+  static values = {
+    backdropColor: { type: String, default: 'rgba(0, 0, 0, 0.8)' }
+  }
 
   connect() {
     // The class we should toggle on the container
@@ -106,7 +109,7 @@ export default class extends Controller {
   }
 
   _backgroundHTML() {
-    return `<div id="${this.backgroundId}" class="fixed top-0 left-0 w-full h-full" style="background-color: rgba(0, 0, 0, 0.8); z-index: 9998;"></div>`;
+    return `<div id="${this.backgroundId}" class="fixed top-0 left-0 w-full h-full" style="background-color: ${this.backdropColorValue}; z-index: 9998;"></div>`;
   }
 
   lockScroll() {


### PR DESCRIPTION
Hey, this adds the option to change the backdrop color and transparency to match the overall site design. By default it will use the existing value - rgba(0, 0, 0, 0.8).