### PR TITLE
Tabs: Add support for horizontal scrolling

### DIFF
--- a/__tests__/tabs_test.js
+++ b/__tests__/tabs_test.js
@@ -30,6 +30,17 @@ describe("TabsController", () => {
       // click first tab
     });
 
+    it("applies aria-selected when tab is clicked", () => {
+      const tabs = document.querySelectorAll("[data-tabs-target='tab']")
+
+      expect(tabs[0].ariaSelected).toEqual("true")
+      expect(tabs[2].ariaSelected).toEqual(null)
+
+      tabs[2].click()
+      expect(tabs[2].ariaSelected).toEqual("true")
+      expect(tabs[0].ariaSelected).toEqual(null)
+    });
+
     it("appends to location href when use-anchor is true", () => {
       const anchorTabCtrlr = document.querySelector("[data-tabs-use-anchor='true']")
       const tab = anchorTabCtrlr.querySelector('#first')

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -37,6 +37,7 @@ export default class extends Controller {
         panel.classList.remove('hidden')
         tab.classList.remove(...this.inactiveTabClasses)
         tab.classList.add(...this.activeTabClasses)
+        tab.ariaSelected = 'true';
 
         // Update URL with the tab ID if it has one
         // This will be automatically selected on page load
@@ -47,8 +48,11 @@ export default class extends Controller {
         panel.classList.add('hidden')
         tab.classList.remove(...this.activeTabClasses)
         tab.classList.add(...this.inactiveTabClasses)
+        tab.ariaSelected = null;
       }
     })
+
+    this.scrollActiveTabIntoView()
   }
 
   get index() {
@@ -62,5 +66,15 @@ export default class extends Controller {
 
   get anchor() {
     return (document.URL.split('#').length > 1) ? document.URL.split('#')[1] : null;
+  }
+
+  // If tabs have horizontal scrolling, the active tab may be out of sight.
+  // Make sure the active tab is visible by scrolling it into the view.
+  scrollActiveTabIntoView() {
+    const activeTab = this.element.querySelector('[aria-selected]');
+    if (activeTab)
+      activeTab.scrollIntoView({
+        inline: 'center',
+      });
   }
 }


### PR DESCRIPTION
I'm using horizontal scrollable tabs in my current project, so the active tab may be out of sight after connecting the controller.

This PR fixes this by changing two things:

* The active tab always gets the attribute `aria-selected="true"`
*  Using `scrollIntoView()` ensures that the active tab is visible

References:

* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected
* https://developer.mozilla.org/en-US/docs/Web/API/Element/ariaSelected
* https://developer.mozilla.org/de/docs/Web/API/Element/scrollIntoView