### PR TITLE
Allow modal to not restore scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,9 @@ that opens the modal and set to `false` to allow it. Default: `true`.
 default action from running when clicking the element (e.g. a link from opening)
 that closes the modal and set to `false` to allow it. Default: `true`.
 
+`data-modal-restore-scroll-value` may be set to `false` to disable
+restoring scroll position.
+
 `data-modal-backdrop-color-value` can be used to specify the color and transparency of the modal's backdrop by setting an rgba value. Default: `rgba(0, 0, 0, 0.8)`.
 
 ### Tabs

--- a/src/modal.js
+++ b/src/modal.js
@@ -32,7 +32,8 @@ import { Controller } from '@hotwired/stimulus';
 export default class extends Controller {
   static targets = ['container']
   static values = {
-    backdropColor: { type: String, default: 'rgba(0, 0, 0, 0.8)' }
+    backdropColor: { type: String, default: 'rgba(0, 0, 0, 0.8)' },
+    restoreScroll: { type: Boolean, default: true }
   }
 
   connect() {
@@ -136,7 +137,9 @@ export default class extends Controller {
     document.body.classList.remove('fixed', 'inset-x-0', 'overflow-hidden');
 
     // Restore the scroll position of the body before it got locked
-    this.restoreScrollPosition();
+    if(this.restoreScrollValue) {
+      this.restoreScrollPosition();
+    }
 
     // Remove the negative top inline style from body
     document.body.style.top = null;


### PR DESCRIPTION
## Background

Sometimes we don't want the modal to restore the scroll position when it's closes. This would be a nice to have feature when scrolling to the top would cause a weird behaviour. Such as my example here


https://user-images.githubusercontent.com/38360603/151157420-77340309-9ce7-4614-affd-7ca28307684e.mov

## A new option

Allows to disable restoring the scroll position via a value attribute.

`data-modal-restore-scroll-value ||= true`
