### PR TITLE
Alert docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ Alerts are set up to slide into view from the top-right side of the
 screen. Clicking on the "X" button will cause the alert to slide back
 out of view and be removed from the DOM.
 
+- `data-alert-dismiss-after-value` can be provided to make the alert dimiss after x miliseconds. Default is `undefined`.
+- `data-alert-show-delay-value` can be set to tell the alert to show itself after x miliseconds. Defaults to `300` miliseconds.
+- `data-alert-remove-delay-value` can be set to tell the alert to hide itself after x milisconds. Defaults to `1100` miliseconds.
+- `data-alert-show-class` is a set of all classes to apply on the alert when it's shown.
+- `data-alert-hide-class` is a set of all classes to apply on the alert when it's hidden.
+
 ### Dropdowns
 
 ![Dropdowns](https://d3vv6lp55qjaqc.cloudfront.net/items/3X1m1v1w2g1M3P0F2p2C/Screen%20Shot%202018-12-07%20at%201.23.52%20PM.png?X-CloudApp-Visitor-Id=bcd17e7039e393c836f30de901088b96&v=4c0ae15f)

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ screen. Clicking on the "X" button will cause the alert to slide back
 out of view and be removed from the DOM.
 
 - `data-alert-dismiss-after-value` can be provided to make the alert dimiss after x miliseconds. Default is `undefined`.
-- `data-alert-show-delay-value` can be set to tell the alert to show itself after x miliseconds. Defaults to `300` miliseconds.
+- `data-alert-show-delay-value` can be set to tell the alert to show itself after x miliseconds. Defaults to `200` miliseconds.
 - `data-alert-remove-delay-value` can be set to tell the alert to hide itself after x milisconds. Defaults to `1100` miliseconds.
 - `data-alert-show-class` is a set of all classes to apply on the alert when it's shown.
 - `data-alert-hide-class` is a set of all classes to apply on the alert when it's hidden.

--- a/src/alert.js
+++ b/src/alert.js
@@ -43,7 +43,7 @@ export default class extends Controller {
   connect() {
     setTimeout(() => {
       this.show()
-    }, this.showAfter)
+    }, this.showDelayValue)
 
     // Auto dimiss if defined
     if (this.hasDismissAfterValue) {
@@ -58,7 +58,7 @@ export default class extends Controller {
 
     setTimeout(() => {
       this.element.remove()
-    }, this.removeAfter)
+    }, this.removeDelayValue)
   }
 
   show() {
@@ -69,13 +69,5 @@ export default class extends Controller {
   hide() {
     this.element.classList.add(...this.hideClasses)
     this.element.classList.remove(...this.showClasses)
-  }
-
-  get removeAfter() {
-    return this.removeDelayValue
-  }
-
-  get showAfter() {
-    return this.showDelayValue
   }
 }

--- a/src/alert.js
+++ b/src/alert.js
@@ -31,9 +31,8 @@ import { Controller } from '@hotwired/stimulus'
 export default class extends Controller {
   static values = {
     dismissAfter: Number,
-    showDelay: Number,
-    removeDelay: Number
-
+    showDelay: { type: Number, default: 200 },
+    removeDelay: { type: Number, default: 1100 }
   }
   static classes = ["show", "hide"]
 
@@ -73,18 +72,10 @@ export default class extends Controller {
   }
 
   get removeAfter() {
-    if (this.hasRemoveDelayValue) {
-      return this.removeDelayValue
-    } else {
-      return 1100
-    }
+    return this.removeDelayValue
   }
 
   get showAfter() {
-    if (this.hasShowDelayValue) {
-      return this.showDelayValue
-    } else {
-      return 200
-    }
+    return this.showDelayValue
   }
 }


### PR DESCRIPTION
Addresses https://github.com/excid3/tailwindcss-stimulus-components/issues/131.

- Document values and classes for `Alert` component.
- Use Stimulus V3's default values instead of checking for presence of the value attribute.

closes https://github.com/excid3/tailwindcss-stimulus-components/issues/131.