### PR TITLE
Fix toggle controller for checkboxes

### DIFF
--- a/src/toggle.js
+++ b/src/toggle.js
@@ -9,7 +9,9 @@ export default class extends Controller {
   }
 
   toggle(event) {
-    event.preventDefault()
+    if (event.target.getAttribute('type') != 'checkbox') {
+      event.preventDefault();
+    }
 
     this.openValue = !this.openValue
   }


### PR DESCRIPTION
`event.preventDefault()` makes checkboxes behave very weird
before when a checkbox was clicked the checkbox would toggle the `toggeable` but the checkbox would not be checked.

This fixes that issue