### PR TITLE
Remove support for module types and targets that are not available for Stimulus 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,10 @@
   "version": "3.0.4",
   "description": "A set of Stimulus components (tabs, dropdowns, modals, toggles, autosave, etc) for TailwindCSS users",
   "source": "src/index.js",
-  "exports": "./dist/tailwindcss-stimulus-components.modern.js",
-  "main": "./dist/tailwindcss-stimulus-components.cjs",
-  "module": "./dist/tailwindcss-stimulus-components.module.js",
+  "main": "./dist/tailwindcss-stimulus-components.umd.js",
+  "module": "./dist/tailwindcss-stimulus-components.modern.js",
   "unpkg": "./dist/tailwindcss-stimulus-components.umd.js",
-  "typings": "./index.d.ts",
+  "types": "./index.d.ts",
   "repository": {
     "url": "https://github.com/excid3/tailwindcss-stimulus-components",
     "type": "git"


### PR DESCRIPTION
Fixes usage of the library with typescript and is inspired by changes made to Stimulus 3 anyway

See https://github.com/excid3/tailwindcss-stimulus-components/issues/151

