### PR TITLE
explicitly show or hide or toggle toggleables

### DIFF
--- a/src/toggle.js
+++ b/src/toggle.js
@@ -14,25 +14,44 @@ export default class extends Controller {
     }
 
     this.openValue = !this.openValue
+    this.toggleToggleables()
   }
 
   hide(event) {
     event.preventDefault();
 
     this.openValue = false;
+    this.hideToggleables()
   }
 
   show(event) {
     event.preventDefault();
 
     this.openValue = true;
+    this.showToggleables()
   }
 
-  openValueChanged() {
+  toggleToggleables() {
     if (!this.toggleClass) { return }
 
     this.toggleableTargets.forEach(target => {
       target.classList.toggle(this.toggleClass)
+    })
+  }
+  
+  showToggleables() {
+    if (!this.toggleClass) { return }
+    
+    this.toggleableTargets.forEach(target => {
+      target.classList.remove(this.toggleClass)
+    })
+  }
+  
+  hideToggleables() {
+    if (!this.toggleClass) { return }
+    
+    this.toggleableTargets.forEach(target => {
+      target.classList.add(this.toggleClass)
     })
   }
 }


### PR DESCRIPTION
This addresses a PR made by me. You can see the PR here. https://github.com/excid3/tailwindcss-stimulus-components/pull/71.

I've realised that the logic for calling `toggle#show` and `toggle#hide` is somewhat wrong with the spirit of `toggle#toggle`.

- when calling `toggle#toggle`, we want to "toggle" all the toggleable classes.
- when calling `toggle#show`, we want to "show" all the toggleables(removing the toggle class).
- when calling `toggle#hide`, we want to "hide" all the toggleables(adding the toggle class).

To accomodate this. I've renamed `openValueChanged` to `toggleToggleables`. And, added two new methods, `showToggleables` and `hideToggleables` methods.


https://user-images.githubusercontent.com/38360603/166901167-edf3a9d9-3647-4447-9693-d699b27879aa.mov

Notice that clicking on "Below" and "Over" "toggles" the toggleable. But, both "below" and "Over" call `toggle#hide`. But, because we are always toggling the classes. We end up with a weird behaviour.