### PR TITLE
add auto-open modal option

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,8 @@ that closes the modal and set to `false` to allow it. Default: `true`.
 `data-modal-restore-scroll-value` may be set to `false` to disable
 restoring scroll position.
 
+`data-modal-auto-open-value` may be set to `true` to auto open the modal when the element first appear in the dom (on connect event).
+
 `data-modal-backdrop-color-value` can be used to specify the color and transparency of the modal's backdrop by setting an rgba value. Default: `rgba(0, 0, 0, 0.8)`.
 
 ### Tabs

--- a/src/modal.js
+++ b/src/modal.js
@@ -33,7 +33,8 @@ export default class extends Controller {
   static targets = ['container']
   static values = {
     backdropColor: { type: String, default: 'rgba(0, 0, 0, 0.8)' },
-    restoreScroll: { type: Boolean, default: true }
+    restoreScroll: { type: Boolean, default: true },
+    autoOpen: { type: Boolean, default: false }
   }
 
   connect() {
@@ -54,19 +55,25 @@ export default class extends Controller {
 
     // Prevent the default action of the clicked element (following a link for example) when closing the modal
     this.preventDefaultActionClosing = (this.data.get('preventDefaultActionClosing') || 'true') === 'true';
+
+    if (this.autoOpenValue) {
+      this.open()
+    }
   }
 
   disconnect() {
     this.close();
   }
 
-  open(e) {
-    if (this.preventDefaultActionOpening) {
-      e.preventDefault();
-    }
+  open(e = null) {
+    if (e) {
+      if (this.preventDefaultActionOpening) {
+        e.preventDefault();
+      }
 
-    if (e.target.blur) {
-      e.target.blur();
+      if (e.target.blur) {
+        e.target.blur();
+      }
     }
 
     // Lock the scroll and save current scroll position


### PR DESCRIPTION
added modal-auto-open-value
when auto-open value is set to true it will open the modal on connect()
event
changed open() function to allow it to be called without params
added the new feature in the readme