### PR TITLE
only add negative top position if restoreScrollValue is true

### DIFF
--- a/src/modal.js
+++ b/src/modal.js
@@ -119,13 +119,13 @@ export default class extends Controller {
     const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
     document.body.style.paddingRight = `${scrollbarWidth}px`;
 
-    // Save the scroll position
-    this.saveScrollPosition();
-
     // Add classes to body to fix its position
     document.body.classList.add('fixed', 'inset-x-0', 'overflow-hidden');
 
     if(this.restoreScrollValue) {
+      // Save the scroll position
+      this.saveScrollPosition();
+      
       // Add negative top position in order for body to stay in place
       document.body.style.top = `-${this.scrollPosition}px`;
     }

--- a/src/modal.js
+++ b/src/modal.js
@@ -125,8 +125,10 @@ export default class extends Controller {
     // Add classes to body to fix its position
     document.body.classList.add('fixed', 'inset-x-0', 'overflow-hidden');
 
-    // Add negative top position in order for body to stay in place
-    document.body.style.top = `-${this.scrollPosition}px`;
+    if(this.restoreScrollValue) {
+      // Add negative top position in order for body to stay in place
+      document.body.style.top = `-${this.scrollPosition}px`;
+    }
   }
 
   unlockScroll() {
@@ -139,10 +141,10 @@ export default class extends Controller {
     // Restore the scroll position of the body before it got locked
     if(this.restoreScrollValue) {
       this.restoreScrollPosition();
+      
+      // Remove the negative top inline style from body
+      document.body.style.top = null;
     }
-
-    // Remove the negative top inline style from body
-    document.body.style.top = null;
   }
 
   saveScrollPosition() {


### PR DESCRIPTION
This addresses the ability to let the modal know that it will or will not restore the scroll value.

When scrollValue is set to false, we need not to add negative top position for the body, moreover, we need not to remove it when unlocking scroll since it's not applied in lockScroll method.

