### PR TITLE
Support for tabs with radio buttons

### DIFF
--- a/__tests__/fixtures/index.html
+++ b/__tests__/fixtures/index.html
@@ -188,6 +188,36 @@
       </div>
     </div>
   </div>
+
+  <div class="my-12">
+    <h2 class="text-2xl text-gray-800 font-semibold mb-4">Radios as Tabs</h2>
+
+    <div id="tabs_with_radios" data-controller="tabs" data-tabs-active-tab="-mb-px border-l border-t border-r rounded-t">
+      <ul class="list-reset flex border-b">
+        <li class="-mb-px mr-1" id="radio_default_tab" data-tabs-target="tab" data-action="click->tabs#change">
+          <label class="bg-white inline-block py-2 px-4 text-blue-600 hover:text-blue-700 font-semibold no-underline cursor-pointer">
+            <input type="radio" value="1" checked="checked" name="radio[option]" id="radio_option_1">
+            Active
+          </label>
+        </li>
+        <li class="mr-1" id="second_radio_tab" data-tabs-target="tab" data-action="click->tabs#change">
+          <label class="bg-white inline-block py-2 px-4 text-blue-600 hover:text-blue-700 font-semibold no-underline cursor-pointer">
+            <input type="radio" value="2" name="radio[option]" id="radio_option_2">
+            Second
+          </label>
+        </li>
+      </ul>
+
+      <div class="hidden py-4 px-4 border-l border-b border-r" data-tabs-target="panel">
+        Tab panel 1
+      </div>
+
+      <div class="hidden py-4 px-4 border-l border-b border-r" data-tabs-target="panel">
+        Tab panel 2
+      </div>
+    </div>
+  </div>
+
 </div>
 
 <!-- Alert -->

--- a/__tests__/tabs_test.js
+++ b/__tests__/tabs_test.js
@@ -42,10 +42,33 @@ describe("TabsController", () => {
       const btn = anchorTabCtrlr.querySelector("[data-id='second']")
       const tab = anchorTabCtrlr.querySelector('#second')
       const activeClass = anchorTabCtrlr.dataset.tabsActiveTab
+      expect(tab.className.includes(activeClass)).toEqual(false)
       btn.click()
       expect(tab.className.includes(activeClass)).toEqual(true)
     });
 
+    it("does not preventDefault to be nice with radios", () => {
+      const firstTab = document.getElementById('radio_default_tab')
+      const secondTab = document.getElementById('second_radio_tab')
+
+      const firstRadio = document.getElementById('radio_option_1')
+      const secondRadio = document.getElementById('radio_option_2')
+
+      const activeClass = document.getElementById('tabs_with_radios').dataset.tabsActiveTab
+
+      expect(firstRadio.checked).toEqual(true)
+      expect(secondRadio.checked).toEqual(false)
+      expect(secondTab.className.includes(activeClass)).toEqual(false)
+
+      secondRadio.click()
+
+      expect(firstRadio.checked).toEqual(false)
+      expect(secondRadio.checked).toEqual(true)
+
+      // still applies the tab classes
+      expect(secondTab.className.includes(activeClass)).toEqual(true)
+
+    })
   });
 });
 

--- a/index.html
+++ b/index.html
@@ -250,6 +250,45 @@
         </div>
       </div>
 
+      <div class="my-12">
+        <h2 class="text-2xl text-gray-800 font-semibold mb-4">Radios as Tabs</h2>
+
+        <div data-controller="tabs" data-tabs-active-tab="-mb-px border-l border-t border-r rounded-t">
+          <ul class="list-reset flex border-b">
+            <li class="-mb-px mr-1" id="radio_default" data-tabs-target="tab" data-action="click->tabs#change">
+              <label class="bg-white inline-block py-2 px-4 text-blue-600 hover:text-blue-700 font-semibold no-underline cursor-pointer">
+                <input type="radio" value="1" checked="checked" name="radio[option]" id="radio_option_1">
+                Active
+              </label>
+            </li>
+            <li class="mr-1" id="second_radio" data-tabs-target="tab" data-action="click->tabs#change">
+              <label class="bg-white inline-block py-2 px-4 text-blue-600 hover:text-blue-700 font-semibold no-underline cursor-pointer">
+                <input type="radio" value="2" name="radio[option]" id="radio_option_2">
+                Second
+              </label>
+            </li>
+            <li class="mr-1" id="third_radio" data-tabs-target="tab">
+              <label class="bg-white inline-block py-2 px-4 text-blue-600 hover:text-blue-700 font-semibold no-underline cursor-pointer">
+                <input type="radio" value="3" name="radio[option]" id="radio_option_3" data-action="click->tabs#change" data-id="third_radio">
+                Third
+              </label>
+            </li>
+          </ul>
+
+          <div class="hidden py-4 px-4 border-l border-b border-r" data-tabs-target="panel">
+            Tab panel 1
+          </div>
+
+          <div class="hidden py-4 px-4 border-l border-b border-r" data-tabs-target="panel">
+            Tab panel 2
+          </div>
+
+          <div class="hidden py-4 px-4 border-l border-b border-r" data-tabs-target="panel">
+            Tab panel 3
+          </div>
+        </div>
+      </div>
+
       <!-- Toggle -->
       <div class="my-12">
         <h2 class="text-2xl text-gray-800 font-semibold mb-4">Toggle</h2>

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -11,8 +11,6 @@ export default class extends Controller {
   }
 
   change(event) {
-    event.preventDefault()
-
     // If target specifies an index, use that
     if (event.currentTarget.dataset.index) {
       this.index = event.currentTarget.dataset.index


### PR DESCRIPTION
`tabs#change preventDefault()` was messing with this nice little trick to use tabs as radio button in some more complex forms:

https://user-images.githubusercontent.com/307759/179628366-961a1017-5117-4163-a226-84f7929f4396.mov

It looks safe for to me to remove it: 

https://user-images.githubusercontent.com/307759/179628659-8cbba724-2fdf-4414-b58d-a765eab6671b.mov

Please point me out if im missing something. 

Thanks! 