### PR TITLE
Add Rails/ujs to Autosave

### DIFF
--- a/src/autosave.js
+++ b/src/autosave.js
@@ -1,4 +1,5 @@
 import { Controller } from '@hotwired/stimulus'
+import Rails from '@rails/ujs'
 
 export default class extends Controller {
   static targets = ['form', 'status']


### PR DESCRIPTION
The current Autosave references `Rails.fire` but does not include Rails. Adding `import Rails from '@rails/ujs'` should address this.