### PR TITLE
V3 upgrades and a little more

### DIFF
--- a/src/alert.js
+++ b/src/alert.js
@@ -26,15 +26,16 @@
 //    </div>
 //  </div>
 
-import { Controller } from '@hotwired/stimulus'
+import {Controller} from '@hotwired/stimulus'
 
 export default class extends Controller {
   static values = {
-    dismissAfter: Number,
-    showDelay: { type: Number, default: 200 },
-    removeDelay: { type: Number, default: 1100 }
+    // zero value means leave open until explicitly closed
+    dismissAfter: {type: Number, default: 0},
+    showDelay: {type: Number, default: 200},
+    removeDelay: {type: Number, default: 1100},
   }
-  static classes = ["show", "hide"]
+  static classes = ['show', 'hide']
 
   initialize() {
     this.hide()
@@ -45,8 +46,8 @@ export default class extends Controller {
       this.show()
     }, this.showDelayValue)
 
-    // Auto dimiss if defined
-    if (this.hasDismissAfterValue) {
+    // Auto dismiss if defined (zero value means leave open)
+    if (this.dismissAfterValue > 0) {
       setTimeout(() => {
         this.close()
       }, this.dismissAfterValue)
@@ -62,12 +63,22 @@ export default class extends Controller {
   }
 
   show() {
-    this.element.classList.add(...this.showClasses)
-    this.element.classList.remove(...this.hideClasses)
+    if (this.hasShowClass) {
+      this.element.classList.add(...this.showClasses)
+    }
+
+    if (this.hasHideClass) {
+      this.element.classList.remove(...this.hideClasses)
+    }
   }
 
   hide() {
-    this.element.classList.add(...this.hideClasses)
-    this.element.classList.remove(...this.showClasses)
+    if (this.hasHideClass) {
+      this.element.classList.add(...this.hideClasses)
+    }
+
+    if (this.hasShowClass) {
+      this.element.classList.remove(...this.showClasses)
+    }
   }
 }

--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -23,7 +23,7 @@
 //  </div>
 // </div>
 
-import {Controller} from '@hotwired/stimulus'
+import { Controller } from '@hotwired/stimulus'
 
 // @menuTarget: is the element that contains the dropdown menu content
 // @buttonTarget: is the element that is annotated with aria-* attributes showing the dropdown state
@@ -49,9 +49,9 @@ export default class extends Controller {
 
   static values = {
     open: Boolean,
-    enterTimeout: {type: Number, default: 300},
-    leaveTimeout: {type: Number, default: 300},
-    removeWindowAction: {type: Boolean, default: false},
+    enterTimeout: { type: Number, default: 300 },
+    leaveTimeout: { type: Number, default: 300 },
+    removeWindowAction: { type: Boolean, default: false },
   }
 
   static classes = ['toggle', 'visible', 'invisible', 'active', 'entering', 'leaving']
@@ -80,10 +80,10 @@ export default class extends Controller {
     // and we'll still do the right thing
     if (this.hasWindowActionTarget) {
       this.removeWindowActionValue = true
+    }
 
-      if (!this.openValue) {
-        this._removeDropdownWindowAction()
-      }
+    if (!this.openValue && this.removeWindowActionValue) {
+      this._removeDropdownWindowAction()
     }
   }
 
@@ -212,7 +212,7 @@ export default class extends Controller {
             if (typeof cb == 'function') cb()
 
             this.menuTarget.classList.add(...this._toggleClasses)
-          }).bind(this), this.leaveTimeoutValue
+          }).bind(this), this.leaveTimeoutValue,
         )
       }).bind(this),
     )
@@ -251,7 +251,7 @@ export default class extends Controller {
         this._arrowUp()
         event.preventDefault()
         break
-      case "ArrowDown":
+      case 'ArrowDown':
         this._arrowDown()
         event.preventDefault()
         break
@@ -287,26 +287,26 @@ export default class extends Controller {
 // private: move one element down in the menu and wrap if necessary
   _arrowDown() {
     if (!this.focusCaptured) {
-      this._focusFirstElement();
+      this._focusFirstElement()
     } else if (this.activeIndex === this._menuItems.length - 1) {
-      this.activeIndex = 0;
-      this._focusFirstElement();
+      this.activeIndex = 0
+      this._focusFirstElement()
     } else {
-      this._menuItems[this.activeIndex + 1].focus();
-      this.activeIndex += 1;
+      this._menuItems[this.activeIndex + 1].focus()
+      this.activeIndex += 1
     }
   }
 
 // private: move one element up in the menu and wrap if necessary
   _arrowUp() {
     if (this.activeIndex === 0) {
-      this._focusLastElement();
-      return;
+      this._focusLastElement()
+      return
     }
 
     if (this.focusCaptured && this.activeIndex >= 1) {
-      this._menuItems[this.activeIndex - 1].focus();
-      this.activeIndex -= 1;
+      this._menuItems[this.activeIndex - 1].focus()
+      this.activeIndex -= 1
     }
   }
 

--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -78,15 +78,21 @@ export default class extends Controller {
     // we attach here because we don't need it unless the dropdown is open
     document.addEventListener('keydown', this._keyboardListener)
 
+    // we do this so the dropdown exists and we can apply transitions to it
+    // hidden elements don't allow transitions to be applied
+    this.menuTarget.classList.add('invisible')
+    this.menuTarget.classList.remove('hidden')
+
     setTimeout(
       (() => {
-        this.menuTarget.classList.remove(this._toggleClasses)
-
         if (this.hasButtonTarget) {
           this.buttonTarget.setAttribute('aria-expanded', 'true')
         } else {
           this.element.setAttribute("aria-expanded", "true")
         }
+
+        this.menuTarget.classList.remove(...this.toggleClasses)
+        this.menuTarget.classList.remove('invisible')
 
         if (this.hasActiveClass) {
           this.element.classList.add(...this.activeClasses)

--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -178,8 +178,6 @@ export default class extends Controller {
   }
 
   _onMenuButtonKeydown = event => {
-    console.log("event key: ", event.key)
-    console.log("event keyCode: ", event.keyCode)
     switch (event.code) {
       case 'Enter':
       case 'Space': // space

--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -24,14 +24,14 @@
 //  </div>
 // </div>
 
-import { Controller } from '@hotwired/stimulus'
+import {Controller} from '@hotwired/stimulus'
 
 export default class extends Controller {
   static targets = ['menu', 'button']
   static values = {
     open: Boolean,
-    enterTimeout: { type: Number, default: 300 },
-    leaveTimeout: { type: Number, default: 300 }
+    enterTimeout: {type: Number, default: 300},
+    leaveTimeout: {type: Number, default: 300}
   }
 
   static classes = ['toggle', 'visible', 'invisible', 'active', 'entering', 'leaving']
@@ -41,7 +41,12 @@ export default class extends Controller {
       this.buttonTarget.addEventListener("keydown", this._onMenuButtonKeydown)
     }
 
-    this.element.setAttribute("aria-haspopup", "true")
+    if (this.hasButtonTarget) {
+      this.buttonTarget.setAttribute('aria-haspopup', 'true')
+    } else {
+      // this is probably wrong, but for backward compatibility
+      this.element.setAttribute('aria-haspopup', 'true')
+    }
   }
 
   disconnect() {
@@ -66,7 +71,12 @@ export default class extends Controller {
     setTimeout(
       (() => {
         this.menuTarget.classList.remove(this._toggleClasses)
-        this.element.setAttribute("aria-expanded", "true")
+
+        if (this.hasButtonTarget) {
+          this.buttonTarget.setAttribute('aria-expanded', 'true')
+        } else {
+          this.element.setAttribute("aria-expanded", "true")
+        }
 
         if (this.hasActiveClass) {
           this.element.classList.add(...this.activeClasses)
@@ -101,6 +111,12 @@ export default class extends Controller {
   _hide(cb) {
     setTimeout(
       (() => {
+        if (this.hasButtonTarget) {
+          this.buttonTarget.setAttribute('aria-expanded', 'false')
+        } else {
+          this.buttonTarget.setAttribute('aria-expanded', 'false')
+        }
+
         if (this.hasActiveClass) {
           this.element.classList.remove(...this.activeClasses)
         }
@@ -130,16 +146,18 @@ export default class extends Controller {
   }
 
   _onMenuButtonKeydown = event => {
+    console.log("event key: ", event.key)
+    console.log("event keyCode: ", event.keyCode)
     switch (event.code) {
       case 'Enter':
-      case 'Space':
+      case 'Space': // space
         event.preventDefault()
         this.toggle()
     }
   }
 
-  show(){
-     this.openValue = true;
+  show() {
+    this.openValue = true;
   }
 
   hide(event) {

--- a/src/toggle.js
+++ b/src/toggle.js
@@ -3,9 +3,11 @@ import { Controller } from '@hotwired/stimulus'
 export default class extends Controller {
   static targets = ['toggleable']
   static values = { open: Boolean }
+  static classes = ['toggle']
 
   connect() {
-    this.toggleClass = this.data.get('class') || 'hidden'
+    // so we can have a default value if one is not supplied
+    this._toggleClass = this.hasToggleClass ? this.toggleClass : 'hidden'
   }
 
   toggle(event) {
@@ -32,7 +34,7 @@ export default class extends Controller {
     if (!this.toggleClass) { return }
 
     this.toggleableTargets.forEach(target => {
-      target.classList.toggle(this.toggleClass)
+      target.classList.toggle(this._toggleClass)
     })
   }
 }


### PR DESCRIPTION
This PR has changes to: alert, toggle, and dropdown.

The changes to alert and toggle are minor -- mostly upgrading to Stimulus V3 and a small feature or two.

The changes to dropdown are more significant.  Unfortunately, I made these changes over time on my local copy to address my projects needs and then attempted to break each set of changes down into conceptual commits.  I attempted to make sure each set of commits worked correctly, but there might be issues between the commits.
* Upgrades to Simulus V3
* Moves the key aria- tags to the buttonTarget from this.element
* Removes the now non-standard way of dealing with css classes
* Adds tab and arrow based navigation to the menu
* Adds an option to dynamically add and remove click@window->dropdown#hide so when the dropdown is closed, it doesn't clutter the console with event messages