### PR TITLE
Ignore hide events that aren't from nodes

### DIFF
--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -129,7 +129,7 @@ export default class extends Controller {
   }
 
   hide(event) {
-    if (this.element.contains(event.target) === false && this.openValue) {
+    if (event.target.nodeType && this.element.contains(event.target) === false && this.openValue) {
       this.openValue = false
     }
   }


### PR DESCRIPTION
I was using `dropdown` on an `input` controller watching for `focus` events:

```html
    <input type="text" name="search" id="search"
      placeholder="Search..."
      data-action="focus->dropdown#toggle blur->dropdown#toggle focus@window->dropdown#hide">
```

Without this fix, I was getting the following error when the `blur` event on the document triggered `hide`:

```
Error invoking action "focus@window->dropdown#hide"

TypeError: Failed to execute 'contains' on 'Node': parameter 1 is not of type 'Node'.
    at extended.hide (dropdown_controller.js:134:22)
    at Binding.invokeWithEvent (stimulus.js:281:25)
    at Binding.handleEvent (stimulus.js:253:18)
    at EventListener.handleEvent (stimulus.js:31:25)
```