### PR TITLE
Fixes accessibility aria attributes

### DIFF
--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -40,14 +40,14 @@ export default class extends Controller {
 
     if (this.hasButtonTarget) {
       this.buttonTarget.addEventListener("keydown", this._onMenuButtonKeydown)
+      this.buttonTarget.setAttribute("aria-haspopup", "true")
     }
-
-    this.element.setAttribute("aria-haspopup", "true")
   }
 
   disconnect() {
     if (this.hasButtonTarget) {
       this.buttonTarget.removeEventListener("keydown", this._onMenuButtonKeydown)
+      this.buttonTarget.removeAttribute("aria-haspopup")
     }
   }
 
@@ -68,7 +68,9 @@ export default class extends Controller {
     setTimeout(
       (() => {
         this.menuTarget.classList.remove(this.toggleClass)
-        this.element.setAttribute("aria-expanded", "true")
+        if (this.hasButtonTarget) {
+          this.buttonTarget.setAttribute("aria-expanded", "true")
+        }
         this._enteringClassList[0].forEach(
           (klass => {
             this.menuTarget.classList.add(klass)
@@ -97,7 +99,9 @@ export default class extends Controller {
   _hide(cb) {
     setTimeout(
       (() => {
-        this.element.setAttribute("aria-expanded", "false")
+        if (this.hasButtonTarget) {
+          this.buttonTarget.setAttribute("aria-expanded", "false")
+        }
         this._invisibleClassList[0].forEach(klass => this.menuTarget.classList.add(klass))
         this._visibleClassList[0].forEach(klass => this.menuTarget.classList.remove(klass))
         this._activeClassList[0].forEach(klass => this.activeTarget.classList.remove(klass))


### PR DESCRIPTION
addresses #121 

When running lighthouse accessibility scan currently there is an issue with the `[aria-*]` attributes:

> [aria-*] attributes do not match their roles
> Each ARIA `role` supports a specific subset of `aria-*` attributes. Mismatching these invalidates the `aria-*` attributes. [Learn more](https://web.dev/aria-allowed-attr/?utm_source=lighthouse&utm_medium=devtools).

This PR moves the aria-* attributes from the dropdown controller element to the `buttonTarget` if there is one defined.

As mentioned in #121 the developer can/should manually add the `aria-controls` & `aria-labelledby` logic, `menu` and `menuitem` roles.