### PR TITLE
Don’t preventDefault when hiding a toggle from a click@window

### DIFF
--- a/src/toggle.js
+++ b/src/toggle.js
@@ -17,7 +17,9 @@ export default class extends Controller {
   }
 
   hide(event) {
-    event.preventDefault();
+    if (event.currentTarget != window) {
+      event.preventDefault(); 
+    }
 
     this.openValue = false;
   }


### PR DESCRIPTION
If you add `click@window->toggle#hide` then all clicks will have `event.preventDefault` which is probably not intended. This will skip the `preventDefault` if the event comes from the window being clicked.

```HTML
<div data-controller='toggle'>
  <div data-action='click->toggle#toggle click@window->toggle#hide'><!-- 2nd action here causes the problem -->
    What is the question?
  </div>

  <div data-toggle-target='toggleable' class="hidden">
    <p>This is the answer</p>
  </div>
</div>
```