### PR TITLE
Adding the ability for the popover to auto dismiss

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,8 @@ application.register('popover', Popover)
 
 `data-popover-translate-y="-128%"` defines the css transform-translate Y value used in positioning the popover. It can be anything from a percentage to rem units to pixels.
 
+`data-alert-dismiss-after-value` can be provided to make the popover dimiss after x miliseconds. Default is `undefined`.
+
 ### Autosave (Rails-only)
 
 Autosaving forms are really helpful for saving drafts of records. This

--- a/src/popover.js
+++ b/src/popover.js
@@ -21,6 +21,9 @@
 import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
+  static values = {
+    dismissAfter: Number
+  }
   static targets = ['content']
 
   // Sets the popover offset using Stimulus data map objects.
@@ -43,8 +46,14 @@ export default class extends Controller {
   toggle() {
     if (this.contentTarget.classList.contains('hidden')) {
       this.contentTarget.classList.remove('hidden')
+
+      if (this.dismissAfterValue) {
+        setTimeout(() => {
+          this.contentTarget.classList.add('hidden')
+        }, this.dismissAfterValue)
+      }
     } else {
       this.contentTarget.classList.add('hidden')
-    }    
+    }
   }
 }

--- a/src/popover.js
+++ b/src/popover.js
@@ -47,7 +47,7 @@ export default class extends Controller {
     if (this.contentTarget.classList.contains('hidden')) {
       this.contentTarget.classList.remove('hidden')
 
-      if (this.dismissAfterValue) {
+      if (this.hasDismissAfterValue) {
         setTimeout(() => {
           this.contentTarget.classList.add('hidden')
         }, this.dismissAfterValue)


### PR DESCRIPTION
Same as with the alerts. Popovers that are triggered by toggle events should have the ability to self dismiss without having to toggle the element again. 