### PR TITLE
Reference data-model-open-value on the modal docs

### DIFF
--- a/docs/modal.md
+++ b/docs/modal.md
@@ -44,3 +44,5 @@ application.register('modal', Modal)
 
 `data-modal-restore-scroll-value` may be set to `false` to disable
 restoring scroll position.
+
+`data-modal-open-value` may be set to `true` to open modal on page load.


### PR DESCRIPTION
As per an issue I had here : #196 and @excid3 recommandation, it would be nice to add the existence of `data-model-open-value` for modals on its doc.