### PR TITLE
Ensures the correct tab opens when visiting a page via a link with a tab anchor

### DIFF
--- a/src/tabs.js
+++ b/src/tabs.js
@@ -8,8 +8,11 @@ export default class extends Controller {
     updateAnchor: Boolean
   }
 
-  connect() {
+  initialize() {
     if (this.anchor) this.indexValue = this.tabTargets.findIndex((tab) => tab.id === this.anchor)
+  }
+
+  connect() {
     this.showTab()
   }
 


### PR DESCRIPTION
indexValueChanged runs after initialize and before connect not allowing this.indexValue to update, causing the first tab to always open.

see: https://stimulus.hotwired.dev/reference/values#change-callbacks

closes #204