### PR TITLE
Remove duplicate `menu` target in `slideover` controller

### DIFF
--- a/src/slideover.js
+++ b/src/slideover.js
@@ -2,7 +2,7 @@ import Dropdown from './dropdown.js'
 import { transition } from './transition'
 
 export default class extends Dropdown {
-  static targets = ['menu', 'overlay', 'close']
+  static targets = ['overlay', 'close']
 
   openValueChanged() {
     transition(this.overlayTarget, this.openValue)


### PR DESCRIPTION
While working on Stimulus LSP I noticed that the `slideover` controller has a duplicate `menu` target. The `dropdown` controller already defines that target and the `slideover` controller is therefore automatically inheriting it.