### PR TITLE
Update web-test-runner concurrency to 1

### DIFF
--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -12,6 +12,7 @@ const filterBrowserLogs = (log) => {
 }
 
 export default {
+  concurrency: 1,
   files: "test/**/*_test.js",
   nodeResolve: true,
   filterBrowserLogs,


### PR DESCRIPTION
This may help reduce the failures we're seeing in CI and local. I actually got pretty consistent result of passing tests locally by reducing the concurrency option to 1.

Similar issue found [here](https://github.com/open-wc/open-wc/issues/1749#issuecomment-654826490)