### PR TITLE
Update popover.md - Fix dismiss-after-value attr name

### DIFF
--- a/docs/popover.md
+++ b/docs/popover.md
@@ -28,4 +28,4 @@ application.register('popover', Popover)
 
 `data-popover-target="content"` defines which element will contain the actual content in the popover.
 
-`data-alert-dismiss-after-value` can be provided to make the popover dimiss after x miliseconds. Default is `undefined`.
+`data-popover-dismiss-after-value` can be provided to make the popover dimiss after x miliseconds. Default is `undefined`.


### PR DESCRIPTION
Small doc fix, the `dismissAfter` value is part of the `popover` controller.

https://github.com/excid3/tailwindcss-stimulus-components/blob/78b1bfc03704ea93419ca5cf7a6d6c4414e69e29/src/popover.js#L27
