### PR TITLE
fix: applies change to event listener registration and cleanup

### DIFF
--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -11,11 +11,12 @@ export default class extends Controller {
   static classes = ['enter', 'enterFrom', 'enterTo', 'leave', 'leaveFrom', 'leaveTo', 'toggle']
 
   connect() {
-    document.addEventListener("turbo:before-cache", this.beforeCache.bind(this))
+    this.boundBeforeCache = this.beforeCache.bind(this)
+    document.addEventListener('turbo:before-cache', this.boundBeforeCache)
   }
 
   disconnect() {
-    document.removeEventListener("turbo:before-cache", this.beforeCache.bind(this))
+    document.removeEventListener('turbo:before-cache', this.boundBeforeCache)
   }
 
   openValueChanged() {

--- a/src/modal.js
+++ b/src/modal.js
@@ -8,11 +8,12 @@ export default class extends Controller {
 
   connect() {
     if (this.openValue) this.open()
-    document.addEventListener("turbo:before-cache", this.beforeCache.bind(this))
+    this.boundBeforeCache = this.beforeCache.bind(this)
+    document.addEventListener("turbo:before-cache", this.boundBeforeCache)
   }
 
   disconnect() {
-    document.removeEventListener("turbo:before-cache", this.beforeCache.bind(this))
+    document.removeEventListener("turbo:before-cache", this.boundBeforeCache)
   }
 
   open() {

--- a/src/slideover.js
+++ b/src/slideover.js
@@ -9,11 +9,12 @@ export default class extends Controller {
 
   connect() {
     if (this.openValue) this.open()
-    document.addEventListener("turbo:before-cache", this.beforeCache.bind(this))
+    this.boundBeforeCache = this.beforeCache
+    document.addEventListener("turbo:before-cache", this.boundBeforeCache)
   }
 
   disconnect() {
-    document.removeEventListener("turbo:before-cache", this.beforeCache.bind(this))
+    document.removeEventListener("turbo:before-cache", this.boundBeforeCache)
   }
 
   open() {


### PR DESCRIPTION
This PR changes the way event listeners are registered on `connect()` for a better removal as per the recommendation in [this](https://www.betterstimulus.com/events) manual.

> When you call .bind() on a function, it creates a new function. Therefore, calling bind twice means the add and remove eventListeners are calling different references of the function and the event wont be removed. Make sure that when adding and removing event listeners you use the same bound function reference.

