### PR TITLE
Adds ability to sync tabs instances by group

### DIFF
--- a/docs/tabs.md
+++ b/docs/tabs.md
@@ -52,6 +52,10 @@ application.register('tabs', Tabs)
 
 `data-tabs-update-anchor-value="true"` can be used to update the URL anchor when the tab changes.
 
+`data-tabs-sync-value="true"` can be used to sync deferent instances of tabs.
+
+`data-tabs-sync-group-value="true"` can be used to sync tabs by groups.
+
 ##### Changing tabs from other places
 
 If you'd like to change the tab from a button or link outside of the tabs, you can call the same method and assign either `data-id` or `data-index` to select the tab.


### PR DESCRIPTION
We have a page that uses the tabs component for inputs in different languages, one tab per language.
We want to be able to change all the tabs at once.
