### PR TITLE
Fix transition options inconsistency/bug

### DIFF
--- a/src/transition.js
+++ b/src/transition.js
@@ -21,10 +21,7 @@ export async function transition(element, state, transitionOptions = {}) {
 // data-transition-leave-from="bg-opacity-80"
 // data-transition-leave-to="bg-opacity-0"
 export async function enter(element, transitionOptions = {}) {
-  const transitionClasses = element.dataset.transitionEnter || transitionOptions.enter || 'enter'
-  const fromClasses = element.dataset.transitionEnterFrom || transitionOptions.enterFrom || 'enter-from'
-  const toClasses = element.dataset.transitionEnterTo || transitionOptions.enterTo || 'enter-to'
-  const toggleClass = element.dataset.toggleClass || transitionOptions.toggleClass || 'hidden'
+  const { transitionClasses, fromClasses, toClasses, toggleClass } = getTransitionOptions("Enter", element, transitionOptions)
 
   return performTransitions(element, {
     firstFrame() {
@@ -44,10 +41,7 @@ export async function enter(element, transitionOptions = {}) {
 }
 
 export async function leave(element, transitionOptions = {}) {
-  const transitionClasses = element.dataset.transitionLeave || transitionOptions.leave || 'leave'
-  const fromClasses = element.dataset.transitionLeaveFrom || transitionOptions.leaveFrom || 'leave-from'
-  const toClasses = element.dataset.transitionLeaveTo || transitionOptions.leaveTo || 'leave-to'
-  const toggleClass = element.dataset.toggleClass || transitionOptions.toggle || 'hidden'
+  const { transitionClasses, fromClasses, toClasses, toggleClass } = getTransitionOptions("Leave", element, transitionOptions)
 
   return performTransitions(element, {
     firstFrame() {
@@ -64,6 +58,15 @@ export async function leave(element, transitionOptions = {}) {
       element.classList.add(...toggleClass.split(' '))
     }
   })
+}
+
+function getTransitionOptions(type, element, transitionOptions) {
+  return {
+    transitionClasses: element.dataset[`transition${type}`] || transitionOptions[type.toLowerCase()] || type.toLowerCase(),
+    fromClasses: element.dataset[`transition${type}From`] || transitionOptions[`${type.toLowerCase()}From`] || `${type.toLowerCase()}-from`,
+    toClasses: element.dataset[`transition${type}To`] || transitionOptions[`${type.toLowerCase()}To`] || `${type.toLowerCase()}-to`,
+    toggleClass: element.dataset.toggleClass || transitionOptions.toggleClass || transitionOptions.toggle || 'hidden'
+  }
 }
 
 function setupTransition(element) {

--- a/test/transition_test.js
+++ b/test/transition_test.js
@@ -115,6 +115,34 @@ describe('Transition', () => {
       await aTimeout(100)
       expect(target.className.split(' ')).to.have.members(['foo', 'opacity-0', 'hidden'])
     })
+
+    it('parses transitionOptions properly', async () => {
+      await fixture(html`
+          <div id="my-div" class="opacity-100">
+            This popover shows on hover
+          </div>
+      `)
+
+      const target = document.getElementById('my-div')
+
+      leave(target, {
+        leave: 'transition-opacity ease-in-out duration-100',
+        leaveFrom: 'opacity-100',
+        leaveTo: 'opacity-0',
+        toggleClass: 'my-hidden'
+      })
+
+      expect(target.className.split(' ')).to.have.members(['opacity-100'])
+
+      await nextFrame()
+      expect(target.className.split(' ')).to.have.members(['transition-opacity', 'ease-in-out', 'duration-100', 'opacity-100'])
+
+      await nextFrame()
+      expect(target.className.split(' ')).to.have.members(['opacity-0', 'transition-opacity', 'ease-in-out', 'duration-100'])
+
+      await aTimeout(0)
+      expect(target.className.split(' ')).to.have.members(['my-hidden', 'opacity-0'])
+    })
   })
 
   describe('enter()', () => {
@@ -133,6 +161,34 @@ describe('Transition', () => {
 
       await aTimeout(100)
       expect(target.className.split(' ')).to.have.members(['foo', 'opacity-100'])
+    })
+
+    it('parses transitionOptions properly', async () => {
+      await fixture(html`
+          <div id="my-div" class="my-hidden">
+            This popover shows on hover
+          </div>
+      `)
+
+      const target = document.getElementById('my-div')
+
+      enter(target, {
+        enter: 'transition-opacity ease-in-out duration-100',
+        enterFrom: 'opacity-0',
+        enterTo: 'opacity-100',
+        toggle: 'my-hidden'
+      })
+
+      expect(target.className.split(' ')).to.have.members(['my-hidden'])
+
+      await nextFrame()
+      expect(target.className.split(' ')).to.have.members(['opacity-0', 'transition-opacity', 'ease-in-out', 'duration-100'])
+
+      await nextFrame()
+      expect(target.className.split(' ')).to.have.members(['transition-opacity', 'ease-in-out', 'duration-100', 'opacity-100'])
+
+      await aTimeout(0)
+      expect(target.className.split(' ')).to.have.members(['opacity-100'])
     })
   })
 

--- a/test/transition_test.js
+++ b/test/transition_test.js
@@ -112,7 +112,7 @@ describe('Transition', () => {
       await nextFrame()
       expect(target.className.split(' ')).to.have.members(['foo', 'transition-opacity', 'ease-in-out', 'duration-100', 'opacity-0'])
 
-      await aTimeout(100)
+      await aTimeout(0)
       expect(target.className.split(' ')).to.have.members(['foo', 'opacity-0', 'hidden'])
     })
 
@@ -159,7 +159,7 @@ describe('Transition', () => {
       await nextFrame()
       expect(target.className.split(' ')).to.have.members(['foo', 'transition-opacity', 'ease-in-out', 'duration-100', 'opacity-100'])
 
-      await aTimeout(100)
+      await aTimeout(0)
       expect(target.className.split(' ')).to.have.members(['foo', 'opacity-100'])
     })
 


### PR DESCRIPTION
I found a bug or inconsistency in how `transitionOptions` are used in the `enter()` and `leave()` functions inside `transition.js`.

`enter()` expects `toggleClass`

```javascript
const toggleClass = element.dataset.toggleClass || transitionOptions.toggleClass || 'hidden'
```

`leave()` expects `toggle`:
```javascript
const toggleClass = element.dataset.toggleClass || transitionOptions.toggle || 'hidden'
```

This patch combines `transitionOption` parsing into one function, `getTransitionOptions,` to keep everything consistent. It also allows for both `toggle` and `toggleClass` options to maintain backward compatibility.

I've added tests to cover this issue. 

As an added bonus, I noticed I was using a couple `await aTimeout(100)` calls in my pull request earlier. They don't need to wait that long, so I changed them to `await aTimeout(0)`. This speeds up the tests by .3 seconds or so. 😃
