### PR TITLE
Update Tabs Component Docs.

### DIFF
--- a/docs/tabs.md
+++ b/docs/tabs.md
@@ -12,13 +12,13 @@ application.register('tabs', Tabs)
 ```html
 <div data-controller="tabs" data-tabs-active-tab-class="-mb-px border-l border-t border-r rounded-t">
   <ul class="list-reset flex border-b">
-    <li class="-mb-px mr-1" data-tabs-target="tab" data-action="click->tabs#change">
+    <li class="-mb-px mr-1" data-tabs-target="tab" data-action="click->tabs#change:prevent">
       <a class="bg-white inline-block py-2 px-4 text-blue-500 hover:text-blue-700 font-semibold no-underline" href="#">Active</a>
     </li>
-    <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
+    <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change:prevent">
       <a class="bg-white inline-block py-2 px-4 text-blue-500 hover:text-blue-700 font-semibold no-underline" href="#">Tab</a>
     </li>
-    <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change">
+    <li class="mr-1" data-tabs-target="tab" data-action="click->tabs#change:prevent">
       <a class="bg-white inline-block py-2 px-4 text-blue-500 hover:text-blue-700 font-semibold no-underline" href="#">Tab</a>
     </li>
     <li class="mr-1">


### PR DESCRIPTION
Sorry, I was facing with the issue that on every click on anchor tag, the tab resets the selected tab.

I was digging into the demo source code and I discovered that the right action is: `change:prevent` instead as `change` (as was in the docs).