### PR TITLE
[Bug] Transition only applying first class

### DIFF
--- a/src/dropdown.js
+++ b/src/dropdown.js
@@ -85,13 +85,13 @@ export default class extends Controller {
   get transitionOptions() {
     // once the Class API default values are available, we can simplify this
     return {
-      enter: this.hasEnterClass ? this.enterClass : 'transition ease-out duration-100',
-      enterFrom: this.hasEnterFromClass ? this.enterFromClass : 'transform opacity-0 scale-95',
-      enterTo: this.hasEnterToClass ? this.enterToClass : 'transform opacity-100 scale-100',
-      leave: this.hasLeaveClass ? this.leaveClass : 'transition ease-in duration-75',
-      leaveFrom: this.hasLeaveFromClass ? this.leaveFromClass : 'transform opacity-100 scale-100',
-      leaveTo: this.hasLeaveToClass ? this.leaveToClass : 'transform opacity-0 scale-95',
-      toggleClass: this.hasToggleClass ? this.toggleClass : 'hidden',
+      enter: this.hasEnterClass ? ...this.enterClasses : 'transition ease-out duration-100',
+      enterFrom: this.hasEnterFromClass ? ...this.enterFromClasses : 'transform opacity-0 scale-95',
+      enterTo: this.hasEnterToClass ? ...this.enterToClasses : 'transform opacity-100 scale-100',
+      leave: this.hasLeaveClass ? ...this.leaveClasses : 'transition ease-in duration-75',
+      leaveFrom: this.hasLeaveFromClass ? ...this.leaveFromClasses : 'transform opacity-100 scale-100',
+      leaveTo: this.hasLeaveToClass ? ...this.leaveToClasses : 'transform opacity-0 scale-95',
+      toggleClass: this.hasToggleClass ? ...this.toggleClasses : 'hidden',
     }
   }
 


### PR DESCRIPTION
Hi !

I just discovered this repo and I was trying the dropdown controller. When I tried to change de transitions style, I realised that it was not working anymore and only applying the first class of the list.

So I'm proposing a quick fix for it, maybe there is others controllers to fix. It's late and I don't have time for this right now.

Thanks for your job and I hope my fix proposal is good.