### PR TITLE
Slideover documentation typo

### DIFF
--- a/docs/slideover.md
+++ b/docs/slideover.md
@@ -34,4 +34,4 @@ application.register('slideover', Slideover)
 
 ### Options
 
-`data-modal-open-value` may be set to `true` to open modal on connect.
+`data-slideover-open-value` may be set to `true` to open slideover on connect.


### PR DESCRIPTION
This changes `modal`-> `slideover`, correcting a documentation typo.